### PR TITLE
Update to use fluo-parent POM and groupIds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+target/
+
+.settings/
+.classpath
+.project
+.idea/
+*.iml
+
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -1,1 +1,18 @@
+<!--
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
 Examples for Apache Fluo

--- a/phrasecount/.gitignore
+++ b/phrasecount/.gitignore
@@ -1,6 +1,0 @@
-.classpath
-.project
-.settings
-target
-.idea
-*.iml

--- a/phrasecount/README.md
+++ b/phrasecount/README.md
@@ -1,3 +1,20 @@
+<!--
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
 # Phrase Count
 
 [![Build Status](https://travis-ci.org/astralway/phrasecount.svg?branch=master)](https://travis-ci.org/astralway/phrasecount)

--- a/phrasecount/bin/copy-jars.sh
+++ b/phrasecount/bin/copy-jars.sh
@@ -1,5 +1,20 @@
 #!/bin/bash
 
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 #This script will copy the phrase count jar and its dependencies to the Fluo
 #application lib dir
 

--- a/phrasecount/bin/load.sh
+++ b/phrasecount/bin/load.sh
@@ -1,3 +1,18 @@
 #!/bin/bash
 
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 mvn exec:java -Dexec.mainClass=phrasecount.cmd.Load -Dexec.args="${*:1}" -Dexec.classpathScope=test

--- a/phrasecount/bin/mini.sh
+++ b/phrasecount/bin/mini.sh
@@ -1,4 +1,19 @@
 #!/bin/bash
 
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 mvn exec:java -Dexec.mainClass=phrasecount.cmd.Mini -Dexec.args="${*:1}" -Dexec.classpathScope=test &>mini.log &
 echo "Started Mini in background.  Writing output to mini.log."

--- a/phrasecount/bin/print.sh
+++ b/phrasecount/bin/print.sh
@@ -1,4 +1,19 @@
 #!/bin/bash
 
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 mvn exec:java -Dexec.mainClass=phrasecount.cmd.Print -Dexec.args="${*:1}" -Dexec.classpathScope=test
 

--- a/phrasecount/bin/run.sh
+++ b/phrasecount/bin/run.sh
@@ -1,5 +1,20 @@
 #!/bin/bash
 
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 BIN_DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 PC_HOME=$( cd "$( dirname "$BIN_DIR" )" && pwd )
 

--- a/phrasecount/pom.xml
+++ b/phrasecount/pom.xml
@@ -1,22 +1,93 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-  <modelVersion>4.0.0</modelVersion>
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
 
-  <groupId>io.github.astralway</groupId>
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.apache.fluo</groupId>
+    <artifactId>fluo-examples</artifactId>
+    <version>1-SNAPSHOT</version>
+  </parent>
   <artifactId>phrasecount</artifactId>
   <version>0.0.1-SNAPSHOT</version>
   <packaging>jar</packaging>
-
   <name>phrasecount</name>
   <url>https://github.com/astralway/phrasecount</url>
-
   <properties>
-    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <accumulo.version>1.7.2</accumulo.version>
-    <fluo.version>1.0.0-incubating</fluo.version>
     <fluo-recipes.version>1.0.0-incubating</fluo-recipes.version>
+    <fluo.version>1.0.0-incubating</fluo.version>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
-
+  <dependencies>
+    <dependency>
+      <groupId>com.beust</groupId>
+      <artifactId>jcommander</artifactId>
+      <version>1.32</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.accumulo</groupId>
+      <artifactId>accumulo-core</artifactId>
+      <version>${accumulo.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.accumulo</groupId>
+      <artifactId>accumulo-minicluster</artifactId>
+      <version>${accumulo.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.fluo</groupId>
+      <artifactId>fluo-api</artifactId>
+      <version>${fluo.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.fluo</groupId>
+      <artifactId>fluo-recipes-accumulo</artifactId>
+      <version>${fluo-recipes.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.fluo</groupId>
+      <artifactId>fluo-recipes-core</artifactId>
+      <version>${fluo-recipes.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.fluo</groupId>
+      <artifactId>fluo-recipes-kryo</artifactId>
+      <version>${fluo-recipes.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.fluo</groupId>
+      <artifactId>fluo-core</artifactId>
+      <version>${fluo.version}</version>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>4.11</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.fluo</groupId>
+      <artifactId>fluo-mini</artifactId>
+      <version>${fluo.version}</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
   <build>
     <plugins>
       <plugin>
@@ -39,60 +110,4 @@
       </plugin>
     </plugins>
   </build>
-
-  <dependencies>
-    <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <version>4.11</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>com.beust</groupId>
-      <artifactId>jcommander</artifactId>
-      <version>1.32</version>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.fluo</groupId>
-      <artifactId>fluo-api</artifactId>
-      <version>${fluo.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.fluo</groupId>
-      <artifactId>fluo-core</artifactId>
-      <version>${fluo.version}</version>
-      <scope>runtime</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.fluo</groupId>
-      <artifactId>fluo-recipes-core</artifactId>
-      <version>${fluo-recipes.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.fluo</groupId>
-      <artifactId>fluo-recipes-accumulo</artifactId>
-      <version>${fluo-recipes.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.fluo</groupId>
-      <artifactId>fluo-recipes-kryo</artifactId>
-      <version>${fluo-recipes.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.accumulo</groupId>
-      <artifactId>accumulo-core</artifactId>
-      <version>${accumulo.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.fluo</groupId>
-      <artifactId>fluo-mini</artifactId>
-      <version>${fluo.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.accumulo</groupId>
-      <artifactId>accumulo-minicluster</artifactId>
-      <version>${accumulo.version}</version>
-    </dependency>
-  </dependencies>
 </project>

--- a/phrasecount/src/main/java/phrasecount/Application.java
+++ b/phrasecount/src/main/java/phrasecount/Application.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package phrasecount;
 
 import org.apache.fluo.api.config.FluoConfiguration;
@@ -57,15 +74,14 @@ public class Application {
             PhraseMap.PcmUpdateObserver.class, String.class, Counts.class,
             opts.phraseCountMapBuckets));
 
-    AccumuloExporter.Configuration accumuloConfig =
-        new AccumuloExporter.Configuration(opts.instance, opts.zookeepers, opts.user, opts.password,
-                                           opts.exportTable);
+    AccumuloExporter.Configuration accumuloConfig = new AccumuloExporter.Configuration(
+        opts.instance, opts.zookeepers, opts.user, opts.password, opts.exportTable);
 
     // setup an Accumulo export queue to to send phrase count updates to an Accumulo table
     ExportQueue.Options exportQueueOpts =
         new ExportQueue.Options(EXPORT_QUEUE_ID, PhraseExporter.class.getName(),
-                                String.class.getName(), Counts.class.getName(),
-                                opts.exportQueueBuckets).setExporterConfiguration(accumuloConfig);
+            String.class.getName(), Counts.class.getName(), opts.exportQueueBuckets)
+                .setExporterConfiguration(accumuloConfig);
     ExportQueue.configure(fluoConfig, exportQueueOpts);
   }
 }

--- a/phrasecount/src/main/java/phrasecount/Constants.java
+++ b/phrasecount/src/main/java/phrasecount/Constants.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package phrasecount;
 
 import org.apache.fluo.api.data.Column;
@@ -16,6 +33,6 @@ public class Constants {
   public static final Column DOC_REF_COUNT_COL = TYPEL.bc().fam("doc").qual("refCount").vis();
 
   public static final String EXPORT_QUEUE_ID = "aeq";
-  //phrase count map id
+  // phrase count map id
   public static final String PCM_ID = "pcm";
 }

--- a/phrasecount/src/main/java/phrasecount/DocumentLoader.java
+++ b/phrasecount/src/main/java/phrasecount/DocumentLoader.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package phrasecount;
 
 import org.apache.fluo.api.client.Loader;

--- a/phrasecount/src/main/java/phrasecount/DocumentObserver.java
+++ b/phrasecount/src/main/java/phrasecount/DocumentObserver.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package phrasecount;
 
 import java.util.HashMap;
@@ -94,8 +111,9 @@ public class DocumentObserver extends AbstractObserver {
   private IndexStatus getStatus(TypedTransactionBase tx, Bytes row) {
     String status = tx.get().row(row).col(INDEX_STATUS_COL).toString();
 
-    if (status == null)
+    if (status == null) {
       return IndexStatus.UNINDEXED;
+    }
 
     return IndexStatus.valueOf(status);
   }

--- a/phrasecount/src/main/java/phrasecount/PhraseExporter.java
+++ b/phrasecount/src/main/java/phrasecount/PhraseExporter.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package phrasecount;
 
 import java.util.function.Consumer;

--- a/phrasecount/src/main/java/phrasecount/PhraseMap.java
+++ b/phrasecount/src/main/java/phrasecount/PhraseMap.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package phrasecount;
 
 import java.util.Iterator;

--- a/phrasecount/src/main/java/phrasecount/cmd/Load.java
+++ b/phrasecount/src/main/java/phrasecount/cmd/Load.java
@@ -1,8 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package phrasecount.cmd;
 
 import java.io.File;
+import java.nio.charset.StandardCharsets;
 
-import com.google.common.base.Charsets;
 import com.google.common.io.Files;
 import org.apache.fluo.api.client.FluoClient;
 import org.apache.fluo.api.client.FluoFactory;
@@ -34,7 +51,7 @@ public class Load {
         for (File txtFile : files) {
           if (txtFile.getName().endsWith(".txt")) {
             String uri = txtFile.toURI().toString();
-            String content = Files.toString(txtFile, Charsets.UTF_8);
+            String content = Files.toString(txtFile, StandardCharsets.UTF_8);
 
             System.out.println("Processing : " + txtFile.toURI());
             le.execute(new DocumentLoader(new Document(uri, content)));

--- a/phrasecount/src/main/java/phrasecount/cmd/Mini.java
+++ b/phrasecount/src/main/java/phrasecount/cmd/Mini.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package phrasecount.cmd;
 
 import java.io.File;
@@ -8,7 +25,6 @@ import java.util.Map;
 import com.beust.jcommander.JCommander;
 import com.beust.jcommander.Parameter;
 import com.beust.jcommander.ParameterException;
-import org.apache.accumulo.core.conf.Property;
 import org.apache.accumulo.minicluster.MemoryUnit;
 import org.apache.accumulo.minicluster.MiniAccumuloCluster;
 import org.apache.accumulo.minicluster.MiniAccumuloConfig;
@@ -45,8 +61,9 @@ public class Mini {
 
     try {
       jc.parse(args);
-      if (params.args == null || params.args.size() != 2)
+      if (params.args == null || params.args.size() != 2) {
         throw new ParameterException("Expected two arguments");
+      }
     } catch (ParameterException pe) {
       System.out.println(pe.getMessage());
       jc.setProgramName(Mini.class.getSimpleName());
@@ -60,8 +77,8 @@ public class Mini {
     if (params.moreMemory) {
       cfg.setMemory(ServerType.TABLET_SERVER, 2, MemoryUnit.GIGABYTE);
       Map<String, String> site = new HashMap<>();
-      site.put(Property.TSERV_DATACACHE_SIZE.getKey(), "768M");
-      site.put(Property.TSERV_INDEXCACHE_SIZE.getKey(), "256M");
+      site.put("tserver.cache.data.size", "768M");
+      site.put("tserver.cache.index.size", "256M");
       cfg.setSiteConfig(site);
     }
 

--- a/phrasecount/src/main/java/phrasecount/cmd/Print.java
+++ b/phrasecount/src/main/java/phrasecount/cmd/Print.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package phrasecount.cmd;
 
 import java.io.File;

--- a/phrasecount/src/main/java/phrasecount/cmd/Setup.java
+++ b/phrasecount/src/main/java/phrasecount/cmd/Setup.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package phrasecount.cmd;
 
 import java.io.File;
@@ -28,8 +45,9 @@ public class Setup {
 
     conn.tableOperations().create(exportTable);
 
-    Options opts = new Options(103, 103, config.getAccumuloInstance(), config.getAccumuloZookeepers(),
-        config.getAccumuloUser(), config.getAccumuloPassword(), exportTable);
+    Options opts =
+        new Options(103, 103, config.getAccumuloInstance(), config.getAccumuloZookeepers(),
+            config.getAccumuloUser(), config.getAccumuloPassword(), exportTable);
 
     FluoConfiguration observerConfig = new FluoConfiguration();
     Application.configure(observerConfig, opts);

--- a/phrasecount/src/main/java/phrasecount/cmd/Split.java
+++ b/phrasecount/src/main/java/phrasecount/cmd/Split.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package phrasecount.cmd;
 
 import java.io.File;

--- a/phrasecount/src/main/java/phrasecount/pojos/Counts.java
+++ b/phrasecount/src/main/java/phrasecount/pojos/Counts.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package phrasecount.pojos;
 
 import com.google.common.base.Objects;
@@ -19,7 +36,8 @@ public class Counts {
   }
 
   public Counts add(Counts other) {
-    return new Counts(this.docPhraseCount + other.docPhraseCount, this.totalPhraseCount + other.totalPhraseCount);
+    return new Counts(this.docPhraseCount + other.docPhraseCount,
+        this.totalPhraseCount + other.totalPhraseCount);
   }
 
   @Override
@@ -39,6 +57,7 @@ public class Counts {
 
   @Override
   public String toString() {
-    return Objects.toStringHelper(this).add("documents", docPhraseCount).add("total", totalPhraseCount).toString();
+    return Objects.toStringHelper(this).add("documents", docPhraseCount)
+        .add("total", totalPhraseCount).toString();
   }
 }

--- a/phrasecount/src/main/java/phrasecount/pojos/Document.java
+++ b/phrasecount/src/main/java/phrasecount/pojos/Document.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package phrasecount.pojos;
 
 import java.util.HashMap;
@@ -26,8 +43,9 @@ public class Document {
   }
 
   public String getHash() {
-    if (hash != null)
+    if (hash != null) {
       return hash;
+    }
 
     Hasher hasher = Hashing.sha1().newHasher();
     String[] tokens = content.toLowerCase().split("[^\\p{Alnum}]+");
@@ -46,8 +64,9 @@ public class Document {
     for (int i = 3; i < tokens.length; i++) {
       String phrase = tokens[i - 3] + " " + tokens[i - 2] + " " + tokens[i - 1] + " " + tokens[i];
       Integer old = phrases.put(phrase, 1);
-      if (old != null)
+      if (old != null) {
         phrases.put(phrase, 1 + old);
+      }
     }
 
     return phrases;

--- a/phrasecount/src/main/java/phrasecount/pojos/PcKryoFactory.java
+++ b/phrasecount/src/main/java/phrasecount/pojos/PcKryoFactory.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package phrasecount.pojos;
 
 import com.esotericsoftware.kryo.Kryo;

--- a/phrasecount/src/main/java/phrasecount/pojos/PhraseAndCounts.java
+++ b/phrasecount/src/main/java/phrasecount/pojos/PhraseAndCounts.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package phrasecount.pojos;
 
 public class PhraseAndCounts extends Counts {

--- a/phrasecount/src/main/java/phrasecount/query/PhraseCountTable.java
+++ b/phrasecount/src/main/java/phrasecount/query/PhraseCountTable.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package phrasecount.query;
 
 import java.util.Iterator;
@@ -27,10 +44,10 @@ public class PhraseCountTable implements Iterable<PhraseAndCounts> {
 
   static final String STAT_CF = "stat";
 
-  //name of column qualifier used to store phrase count across all documents
+  // name of column qualifier used to store phrase count across all documents
   static final String TOTAL_PC_CQ = "totalCount";
 
-  //name of column qualifier used to store number of documents containing a phrase
+  // name of column qualifier used to store number of documents containing a phrase
   static final String DOC_PC_CQ = "docCount";
 
   public static Mutation createMutation(String phrase, long seq, Counts pc) {
@@ -38,15 +55,17 @@ public class PhraseCountTable implements Iterable<PhraseAndCounts> {
 
     // use the sequence number for the Accumulo timestamp, this will cause older updates to fall
     // behind newer ones
-    if (pc.totalPhraseCount == 0)
+    if (pc.totalPhraseCount == 0) {
       mutation.putDelete(STAT_CF, TOTAL_PC_CQ, seq);
-    else
+    } else {
       mutation.put(STAT_CF, TOTAL_PC_CQ, seq, pc.totalPhraseCount + "");
+    }
 
-    if (pc.docPhraseCount == 0)
+    if (pc.docPhraseCount == 0) {
       mutation.putDelete(STAT_CF, DOC_PC_CQ, seq);
-    else
+    } else {
       mutation.put(STAT_CF, DOC_PC_CQ, seq, pc.docPhraseCount + "");
+    }
 
     return mutation;
   }
@@ -97,7 +116,8 @@ public class PhraseCountTable implements Iterable<PhraseAndCounts> {
       scanner.fetchColumn(new Text(STAT_CF), new Text(TOTAL_PC_CQ));
       scanner.fetchColumn(new Text(STAT_CF), new Text(DOC_PC_CQ));
 
-      return Iterators.transform(new RowIterator(scanner), new RowTransform());
+      RowTransform transform = new RowTransform();
+      return Iterators.transform(new RowIterator(scanner), transform::apply);
     } catch (RuntimeException e) {
       throw e;
     } catch (Exception e) {

--- a/phrasecount/src/main/java/phrasecount/query/RowTransform.java
+++ b/phrasecount/src/main/java/phrasecount/query/RowTransform.java
@@ -1,9 +1,26 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package phrasecount.query;
 
 import java.util.Iterator;
 import java.util.Map.Entry;
+import java.util.function.Function;
 
-import com.google.common.base.Function;
 import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.Value;
 import phrasecount.pojos.PhraseAndCounts;
@@ -20,13 +37,15 @@ public class RowTransform implements Function<Iterator<Entry<Key, Value>>, Phras
       Entry<Key, Value> colEntry = input.next();
       String cq = colEntry.getKey().getColumnQualifierData().toString();
 
-      if (cq.equals(PhraseCountTable.TOTAL_PC_CQ))
+      if (cq.equals(PhraseCountTable.TOTAL_PC_CQ)) {
         totalPhraseCount = Integer.parseInt(colEntry.getValue().toString());
-      else
+      } else {
         docPhraseCount = Integer.parseInt(colEntry.getValue().toString());
+      }
 
-      if (phrase == null)
+      if (phrase == null) {
         phrase = colEntry.getKey().getRowData().toString();
+      }
     }
 
     return new PhraseAndCounts(phrase, docPhraseCount, totalPhraseCount);

--- a/phrasecount/src/test/java/phrasecount/PhraseCounterTest.java
+++ b/phrasecount/src/test/java/phrasecount/PhraseCounterTest.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package phrasecount;
 
 import java.util.Random;
@@ -137,9 +154,10 @@ public class PhraseCounterTest {
       Assert.assertEquals(new Counts(0, 0), pcTable.getPhraseCounts("test do not panic"));
 
       String oldHash = new Document("/foo3", "This is only a test").getHash();
-      try(TypedSnapshot tsnap = TYPEL.wrap(fluoClient.newSnapshot())){
+      try (TypedSnapshot tsnap = TYPEL.wrap(fluoClient.newSnapshot())) {
         Assert.assertNotNull(tsnap.get().row("doc:" + oldHash).col(DOC_CONTENT_COL).toString());
-        Assert.assertEquals(1, tsnap.get().row("doc:" + oldHash).col(DOC_REF_COUNT_COL).toInteger(0));
+        Assert.assertEquals(1,
+            tsnap.get().row("doc:" + oldHash).col(DOC_REF_COUNT_COL).toInteger(0));
       }
       // dereference document that foo3 was referencing
       loadDocument(fluoClient, "/foo3", "The test is over, for now.");
@@ -148,7 +166,7 @@ public class PhraseCounterTest {
       Assert.assertEquals(new Counts(0, 0), pcTable.getPhraseCounts("is only a test"));
       Assert.assertEquals(new Counts(0, 0), pcTable.getPhraseCounts("test do not panic"));
 
-      try(TypedSnapshot tsnap = TYPEL.wrap(fluoClient.newSnapshot())){
+      try (TypedSnapshot tsnap = TYPEL.wrap(fluoClient.newSnapshot())) {
         Assert.assertNull(tsnap.get().row("doc:" + oldHash).col(DOC_CONTENT_COL).toString());
         Assert.assertNull(tsnap.get().row("doc:" + oldHash).col(DOC_REF_COUNT_COL).toInteger());
       }

--- a/pom.xml
+++ b/pom.xml
@@ -15,26 +15,27 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<!DOCTYPE log4j:configuration SYSTEM "log4j.dtd">
-<log4j:configuration xmlns:log4j="http://jakarta.apache.org/log4j/">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
 
-	<appender name="console" class="org.apache.log4j.ConsoleAppender">
-		<param name="Target" value="System.out"/>
-		<layout class="org.apache.log4j.PatternLayout">
-			<param name="ConversionPattern" value="%d{ISO8601} [%-8c{2}] %-5p: %m%n" />
-		</layout>
-	</appender>
+  <parent>
+    <groupId>org.apache.fluo</groupId>
+    <artifactId>fluo-parent</artifactId>
+    <version>3</version>
+  </parent>
+  <groupId>org.apache.fluo</groupId>
+  <artifactId>fluo-examples</artifactId>
+  <version>1-SNAPSHOT</version>
+  <packaging>pom</packaging>
 
-	<logger name="org.apache.zookeeper">
-		<level value="ERROR" />
-	</logger>
+  <name>Fluo Examples</name>
+  <description>This repo contains several example applications for Apache Fluo</description>
+  <url>https://fluo.apache.org</url>
 
-	<logger name="org.apache.curator">
-		<level value="ERROR" />
-	</logger>
+  <modules>
+    <module>stresso</module>
+    <module>phrasecount</module>
+    <module>webindex</module>
+  </modules>
 
-	<root>
-		<level value="INFO" />
-		<appender-ref ref="console" />
-	</root>
-</log4j:configuration>
+</project>

--- a/stresso/.gitignore
+++ b/stresso/.gitignore
@@ -1,10 +1,2 @@
-.classpath
-.project
-.settings
-target
-.DS_Store
-.idea
-*.iml
-git/
 logs/
 lib/

--- a/stresso/README.md
+++ b/stresso/README.md
@@ -1,3 +1,19 @@
+<!--
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
 
 # Stresso
 

--- a/stresso/bin/build.sh
+++ b/stresso/bin/build.sh
@@ -1,5 +1,20 @@
 #!/bin/bash
 
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 BIN_DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 SKIP_JAR_CHECKS="true"
 

--- a/stresso/bin/bulk_load.sh
+++ b/stresso/bin/bulk_load.sh
@@ -1,5 +1,20 @@
 #!/bin/bash
 
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 BIN_DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 . $BIN_DIR/load-env.sh
 

--- a/stresso/bin/compact-ll.sh
+++ b/stresso/bin/compact-ll.sh
@@ -1,5 +1,20 @@
 #!/bin/bash
 
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 BIN_DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 . $BIN_DIR/load-env.sh
 

--- a/stresso/bin/diff.sh
+++ b/stresso/bin/diff.sh
@@ -1,5 +1,20 @@
 #!/bin/bash
 
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 BIN_DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 . $BIN_DIR/load-env.sh
 

--- a/stresso/bin/generate.sh
+++ b/stresso/bin/generate.sh
@@ -1,5 +1,20 @@
 #!/bin/bash
 
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 BIN_DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 . $BIN_DIR/load-env.sh
 

--- a/stresso/bin/load-env.sh
+++ b/stresso/bin/load-env.sh
@@ -1,3 +1,20 @@
+#!/bin/bash
+
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 if [ ! -f $BIN_DIR/../conf/env.sh ] 
 then
   . $BIN_DIR/../conf/env.sh.example

--- a/stresso/bin/load.sh
+++ b/stresso/bin/load.sh
@@ -1,5 +1,20 @@
 #!/bin/bash
 
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 BIN_DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 . $BIN_DIR/load-env.sh
 

--- a/stresso/bin/print.sh
+++ b/stresso/bin/print.sh
@@ -1,5 +1,20 @@
 #!/bin/bash
 
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 BIN_DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 . $BIN_DIR/load-env.sh
 

--- a/stresso/bin/run-test.sh
+++ b/stresso/bin/run-test.sh
@@ -1,5 +1,20 @@
 #!/bin/bash
 
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 BIN_DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 
 . $BIN_DIR/load-env.sh

--- a/stresso/bin/split.sh
+++ b/stresso/bin/split.sh
@@ -1,5 +1,20 @@
 #!/bin/bash
 
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 BIN_DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 . $BIN_DIR/load-env.sh
 

--- a/stresso/bin/unique.sh
+++ b/stresso/bin/unique.sh
@@ -1,5 +1,20 @@
 #!/bin/bash
 
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 BIN_DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 . $BIN_DIR/load-env.sh
 

--- a/stresso/conf/env.sh.example
+++ b/stresso/conf/env.sh.example
@@ -1,3 +1,19 @@
+
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 ###############################
 # configuration for all scripts
 ###############################

--- a/stresso/pom.xml
+++ b/stresso/pom.xml
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  Copyright 2014 Stresso authors (see AUTHORS)
-
-  Licensed under the Apache License, Version 2.0 (the "License");
-  you may not use this file except in compliance with the License.
-  You may obtain a copy of the License at
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
 
       http://www.apache.org/licenses/LICENSE-2.0
 
@@ -16,131 +17,37 @@
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
-
-  <groupId>io.github.astralway</groupId>
+  <parent>
+    <groupId>org.apache.fluo</groupId>
+    <artifactId>fluo-examples</artifactId>
+    <version>1-SNAPSHOT</version>
+  </parent>
   <artifactId>stresso</artifactId>
   <version>0.0.1-SNAPSHOT</version>
   <packaging>jar</packaging>
-
   <name>Stresso</name>
   <description>This repo contains an example application designed to stress Apache Fluo</description>
   <url>https://github.com/astralway/stresso</url>
-
   <properties>
-    <accumulo.version>2.0.0-alpha-2</accumulo.version>
     <accumulo-plugin.version>2.0.0-SNAPSHOT</accumulo-plugin.version>
-    <hadoop.version>3.1.1</hadoop.version>
-    <fluo.version>1.2.0</fluo.version>
+    <accumulo.version>2.0.0-alpha-2</accumulo.version>
     <fluo-recipes.version>1.2.0</fluo-recipes.version>
+    <fluo.version>1.2.0</fluo.version>
+    <hadoop.version>3.1.1</hadoop.version>
     <slf4j.version>1.7.12</slf4j.version>
   </properties>
-
-  <profiles>
-    <profile>
-      <id>mini-accumulo</id>
-      <activation>
-        <property>
-          <name>!skipTests</name>
-        </property>
-      </activation>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.apache.accumulo</groupId>
-            <artifactId>accumulo-maven-plugin</artifactId>
-	    <version>${accumulo-plugin.version}</version>
-            <configuration>
-              <instanceName>it-instance-maven</instanceName>
-              <rootPassword>ITSecret</rootPassword>
-            </configuration>
-            <executions>
-              <execution>
-                <id>run-plugin</id>
-                <goals>
-                  <goal>start</goal>
-                  <goal>stop</goal>
-                </goals>
-              </execution>
-            </executions>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-  </profiles>
-
-  <build>
-    <plugins>
-      <plugin>
-        <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.1</version>
-        <configuration>
-          <source>1.8</source>
-          <target>1.8</target>
-          <optimize>true</optimize>
-          <encoding>UTF-8</encoding>
-        </configuration>
-      </plugin>
-
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-	<artifactId>maven-failsafe-plugin</artifactId>
-	<version>3.0.0-M1</version>
-        <configuration>
-          <systemPropertyVariables>
-            <fluo.it.instance.name>it-instance-maven</fluo.it.instance.name>
-            <fluo.it.instance.clear>false</fluo.it.instance.clear>
-          </systemPropertyVariables>
-        </configuration>
-        <executions>
-          <execution>
-            <id>run-integration-tests</id>
-            <goals>
-              <goal>integration-test</goal>
-              <goal>verify</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
-
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-	<artifactId>maven-shade-plugin</artifactId>
-	<version>3.2.1</version>
-        <executions>
-          <execution>
-            <goals>
-              <goal>shade</goal>
-            </goals>
-            <phase>package</phase>
-            <configuration>
-              <shadedArtifactAttached>true</shadedArtifactAttached>
-              <shadedClassifierName>shaded</shadedClassifierName>
-              <filters>
-                <filter>
-                  <artifact>*:*</artifact>
-                  <excludes>
-                    <exclude>META-INF/*.SF</exclude>
-                    <exclude>META-INF/*.DSA</exclude>
-                    <exclude>META-INF/*.RSA</exclude>
-                  </excludes>
-                </filter>
-              </filters>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
-
-    </plugins>
-  </build>
-
   <!--
        The provided scope is used for dependencies that should not end up in
        the shaded jar.  The shaded jar is used to run map reduce jobs via the yarn
        command.  The yarn command will provided hadoop dependencies, so they are not
        needed in the shaded jar.
   -->
-
   <dependencies>
+    <dependency>
+      <groupId>org.apache.accumulo</groupId>
+      <artifactId>accumulo-core</artifactId>
+      <version>${accumulo.version}</version>
+    </dependency>
     <dependency>
       <groupId>org.apache.fluo</groupId>
       <artifactId>fluo-api</artifactId>
@@ -162,9 +69,9 @@
       <version>${fluo-recipes.version}</version>
     </dependency>
     <dependency>
-      <groupId>org.apache.accumulo</groupId>
-      <artifactId>accumulo-core</artifactId>
-      <version>${accumulo.version}</version>
+      <groupId>org.apache.fluo</groupId>
+      <artifactId>fluo-recipes-test</artifactId>
+      <version>${fluo-recipes.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.hadoop</groupId>
@@ -196,6 +103,12 @@
       <version>${slf4j.version}</version>
       <scope>provided</scope>
     </dependency>
+    <dependency>
+      <groupId>commons-io</groupId>
+      <artifactId>commons-io</artifactId>
+      <version>2.4</version>
+      <scope>test</scope>
+    </dependency>
     <!-- Test Dependencies -->
     <dependency>
       <groupId>junit</groupId>
@@ -215,16 +128,98 @@
       <version>${fluo.version}</version>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>org.apache.fluo</groupId>
-      <artifactId>fluo-recipes-test</artifactId>
-      <version>${fluo-recipes.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>commons-io</groupId>
-      <artifactId>commons-io</artifactId>
-      <version>2.4</version>
-      <scope>test</scope>
-    </dependency>
   </dependencies>
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.1</version>
+        <configuration>
+          <source>1.8</source>
+          <target>1.8</target>
+          <optimize>true</optimize>
+          <encoding>UTF-8</encoding>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-failsafe-plugin</artifactId>
+        <version>3.0.0-M1</version>
+        <configuration>
+          <systemPropertyVariables>
+            <fluo.it.instance.name>it-instance-maven</fluo.it.instance.name>
+            <fluo.it.instance.clear>false</fluo.it.instance.clear>
+          </systemPropertyVariables>
+        </configuration>
+        <executions>
+          <execution>
+            <id>run-integration-tests</id>
+            <goals>
+              <goal>integration-test</goal>
+              <goal>verify</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-shade-plugin</artifactId>
+        <version>3.2.1</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+            <phase>package</phase>
+            <configuration>
+              <shadedArtifactAttached>true</shadedArtifactAttached>
+              <shadedClassifierName>shaded</shadedClassifierName>
+              <filters>
+                <filter>
+                  <artifact>*:*</artifact>
+                  <excludes>
+                    <exclude>META-INF/*.SF</exclude>
+                    <exclude>META-INF/*.DSA</exclude>
+                    <exclude>META-INF/*.RSA</exclude>
+                  </excludes>
+                </filter>
+              </filters>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+  <profiles>
+    <profile>
+      <id>mini-accumulo</id>
+      <activation>
+        <property>
+          <name>!skipTests</name>
+        </property>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.accumulo</groupId>
+            <artifactId>accumulo-maven-plugin</artifactId>
+            <version>${accumulo-plugin.version}</version>
+            <configuration>
+              <instanceName>it-instance-maven</instanceName>
+              <rootPassword>ITSecret</rootPassword>
+            </configuration>
+            <executions>
+              <execution>
+                <id>run-plugin</id>
+                <goals>
+                  <goal>start</goal>
+                  <goal>stop</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
 </project>

--- a/stresso/src/main/java/stresso/trie/AccumuloUtil.java
+++ b/stresso/src/main/java/stresso/trie/AccumuloUtil.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package stresso.trie;
 
 import org.apache.accumulo.core.client.Accumulo;
@@ -28,9 +45,9 @@ public class AccumuloUtil {
     try (FluoAdmin fadmin = FluoFactory.newAdmin(fc)) {
       FluoConfiguration appCfg = new FluoConfiguration(fadmin.getApplicationConfig());
       appCfg.setApplicationName(fc.getApplicationName());
-      AccumuloClient client = Accumulo.newClient()
-          .to(appCfg.getAccumuloInstance(), appCfg.getAccumuloZookeepers())
-          .as(appCfg.getAccumuloUser(), appCfg.getAccumuloPassword()).build();
+      AccumuloClient client =
+          Accumulo.newClient().to(appCfg.getAccumuloInstance(), appCfg.getAccumuloZookeepers())
+              .as(appCfg.getAccumuloUser(), appCfg.getAccumuloPassword()).build();
       return tableOp.run(client.tableOperations(), appCfg.getAccumuloTable());
     } catch (Exception e) {
       throw new RuntimeException(e);

--- a/stresso/src/main/java/stresso/trie/CompactLL.java
+++ b/stresso/src/main/java/stresso/trie/CompactLL.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package stresso.trie;
 
 import java.io.File;

--- a/stresso/src/main/java/stresso/trie/Constants.java
+++ b/stresso/src/main/java/stresso/trie/Constants.java
@@ -1,16 +1,20 @@
 /*
- * Copyright 2014 Stresso authors (see AUTHORS)
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied. See the License for the specific language governing permissions and limitations under
- * the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
+
 package stresso.trie;
 
 import org.apache.fluo.api.data.Column;

--- a/stresso/src/main/java/stresso/trie/Diff.java
+++ b/stresso/src/main/java/stresso/trie/Diff.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package stresso.trie;
 
 import java.io.File;
@@ -63,8 +80,9 @@ public class Diff {
     try (FluoClient client = FluoFactory.newClient(config); Snapshot snap = client.newSnapshot()) {
 
       StressoConfig sconf = StressoConfig.retrieve(client);
-      
-      Map<String, Long> rootCounts = getRootCount(client, snap, sconf.stopLevel, sconf.stopLevel, sconf.nodeSize);
+
+      Map<String, Long> rootCounts =
+          getRootCount(client, snap, sconf.stopLevel, sconf.stopLevel, sconf.nodeSize);
       ArrayList<String> rootRows = new ArrayList<>(rootCounts.keySet());
       Collections.sort(rootRows);
 
@@ -72,7 +90,8 @@ public class Diff {
       for (int level = sconf.stopLevel + 1; level <= 8; level++) {
         System.out.printf("Level %d:\n", level);
 
-        Map<String, Long> counts = getRootCount(client, snap, level, sconf.stopLevel, sconf.nodeSize);
+        Map<String, Long> counts =
+            getRootCount(client, snap, level, sconf.stopLevel, sconf.nodeSize);
 
         long sum = 0;
 

--- a/stresso/src/main/java/stresso/trie/Generate.java
+++ b/stresso/src/main/java/stresso/trie/Generate.java
@@ -1,11 +1,12 @@
 /*
- * Copyright 2014 Stresso authors (see AUTHORS)
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -67,7 +68,7 @@ public class Generate extends Configured implements Tool {
 
   }
 
-  public static class RandomLongInputFormat implements InputFormat<LongWritable,NullWritable> {
+  public static class RandomLongInputFormat implements InputFormat<LongWritable, NullWritable> {
 
     @Override
     public InputSplit[] getSplits(JobConf job, int numSplits) throws IOException {
@@ -79,12 +80,13 @@ public class Generate extends Configured implements Tool {
     }
 
     @Override
-    public RecordReader<LongWritable,NullWritable> getRecordReader(InputSplit split, JobConf job, Reporter reporter) throws IOException {
+    public RecordReader<LongWritable, NullWritable> getRecordReader(InputSplit split, JobConf job,
+        Reporter reporter) throws IOException {
 
       final int numToGen = job.getInt(TRIE_GEN_NUM_PER_MAPPER_PROP, 1);
       final long max = job.getLong(TRIE_GEN_MAX_PROP, Long.MAX_VALUE);
 
-      return new RecordReader<LongWritable,NullWritable>() {
+      return new RecordReader<LongWritable, NullWritable>() {
 
         private Random random = new Random();
         private int count = 0;
@@ -92,10 +94,11 @@ public class Generate extends Configured implements Tool {
         @Override
         public boolean next(LongWritable key, NullWritable value) throws IOException {
 
-          if (count == numToGen)
+          if (count == numToGen) {
             return false;
+          }
 
-          key.set((random.nextLong() & 0x7fffffffffffffffl) % max);
+          key.set((random.nextLong() & 0x7fffffffffffffffL) % max);
           count++;
           return true;
         }
@@ -130,14 +133,15 @@ public class Generate extends Configured implements Tool {
   public int run(String[] args) throws Exception {
 
     if (args.length != 4) {
-      log.error("Usage: " + this.getClass().getSimpleName() + " <numMappers> <numbersPerMapper> <max> <output dir>");
+      log.error("Usage: " + this.getClass().getSimpleName()
+          + " <numMappers> <numbersPerMapper> <max> <output dir>");
       System.exit(-1);
     }
 
     int numMappers = Integer.parseInt(args[0]);
     int numPerMapper = Integer.parseInt(args[1]);
     long max = Long.parseLong(args[2]);
-    Path out = new Path(args[3]);
+    final Path out = new Path(args[3]);
 
     Preconditions.checkArgument(numMappers > 0, "numMappers <= 0");
     Preconditions.checkArgument(numPerMapper > 0, "numPerMapper <= 0");

--- a/stresso/src/main/java/stresso/trie/Init.java
+++ b/stresso/src/main/java/stresso/trie/Init.java
@@ -1,15 +1,18 @@
 /*
- * Copyright 2014 Stresso authors (see AUTHORS)
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied. See the License for the specific language governing permissions and limitations under
- * the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package stresso.trie;
@@ -80,10 +83,11 @@ public class Init extends Configured implements Tool {
       while (node != null) {
         outputKey.set(node.getRowId());
         context.write(outputKey, ONE);
-        if (node.getLevel() <= stopLevel)
+        if (node.getLevel() <= stopLevel) {
           node = null;
-        else
+        } else {
           node = node.getParent();
+        }
       }
     }
   }
@@ -140,8 +144,9 @@ public class Init extends Configured implements Tool {
     Path tmp = new Path(args[3]);
 
     int ret = unique(input, new Path(tmp, "nums"));
-    if (ret != 0)
+    if (ret != 0) {
       return ret;
+    }
 
     return buildTree(props, tmp);
   }
@@ -171,7 +176,7 @@ public class Init extends Configured implements Tool {
   }
 
   private int buildTree(FluoConfiguration props, Path tmp) throws Exception {
-    StressoConfig sconf = StressoConfig.retrieve(props);
+    final StressoConfig sconf = StressoConfig.retrieve(props);
 
     Job job = Job.getInstance(getConf());
 

--- a/stresso/src/main/java/stresso/trie/Load.java
+++ b/stresso/src/main/java/stresso/trie/Load.java
@@ -1,15 +1,18 @@
 /*
- * Copyright 2014 Stresso authors (see AUTHORS)
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied. See the License for the specific language governing permissions and limitations under
- * the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package stresso.trie;
@@ -49,13 +52,14 @@ public class Load extends Configured implements Tool {
   public int run(String[] args) throws Exception {
 
     if (args.length != 3) {
-      log.error("Usage: " + this.getClass().getSimpleName() + "<fluo conn props> <app name> <input dir>");
+      log.error(
+          "Usage: " + this.getClass().getSimpleName() + "<fluo conn props> <app name> <input dir>");
       System.exit(-1);
     }
 
     FluoConfiguration props = new FluoConfiguration(new File(args[0]));
     props.setApplicationName(args[1]);
-    Path input = new Path(args[2]);
+    final Path input = new Path(args[2]);
 
     Job job = Job.getInstance(getConf());
 

--- a/stresso/src/main/java/stresso/trie/Node.java
+++ b/stresso/src/main/java/stresso/trie/Node.java
@@ -1,11 +1,12 @@
 /*
- * Copyright 2014 Stresso authors (see AUTHORS)
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,6 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package stresso.trie;
 
 import com.google.common.base.Strings;
@@ -20,7 +22,8 @@ import com.google.common.hash.Hashing;
 
 import static com.google.common.base.Preconditions.checkArgument;
 
-/** Utility class that represents trie node
+/**
+ * Utility class that represents trie node
  */
 public class Node {
 
@@ -28,7 +31,7 @@ public class Node {
   private final int level;
   private final int nodeSize;
 
-  static final int HASH_LEN=4;
+  static final int HASH_LEN = 4;
 
   public Node(Number number, int level, int nodeSize) {
     this.number = number;
@@ -38,7 +41,7 @@ public class Node {
 
   public Node(String rowId) {
     String[] rowArgs = rowId.split(":");
-    checkArgument(validRowId(rowArgs), "Invalid row id - "+ rowId);
+    checkArgument(validRowId(rowArgs), "Invalid row id - " + rowId);
     this.level = Integer.parseInt(rowArgs[0]);
     this.nodeSize = Integer.parseInt(rowArgs[2]);
     this.number = parseNumber(rowArgs[3]);
@@ -70,12 +73,15 @@ public class Node {
     }
   }
 
-  private String genHash(){
-    long num = (number == null)? 0l : number.longValue();
-    int hash = Hashing.murmur3_32().newHasher().putInt(level).putInt(nodeSize).putLong(num).hash().asInt();
+  private String genHash() {
+    long num = (number == null) ? 0L : number.longValue();
+    int hash =
+        Hashing.murmur3_32().newHasher().putInt(level).putInt(nodeSize).putLong(num).hash().asInt();
     hash = hash & 0x7fffffff;
-    //base 36 gives a lot more bins in 4 bytes than hex, but it still human readable which is nice for debugging.
-    String hashString = Strings.padStart(Integer.toString(hash, Character.MAX_RADIX), HASH_LEN, '0');
+    // base 36 gives a lot more bins in 4 bytes than hex, but it still human readable which is nice
+    // for debugging.
+    String hashString =
+        Strings.padStart(Integer.toString(hash, Character.MAX_RADIX), HASH_LEN, '0');
     return hashString.substring(hashString.length() - HASH_LEN);
   }
 
@@ -98,17 +104,18 @@ public class Node {
       if (number instanceof Long) {
         int shift = (((64 / nodeSize) - level) * nodeSize) + nodeSize;
         Long parent = (number.longValue() >> shift) << shift;
-        return new Node(parent, level-1, nodeSize);
+        return new Node(parent, level - 1, nodeSize);
       } else {
         int shift = (((32 / nodeSize) - level) * nodeSize) + nodeSize;
         Integer parent = (number.intValue() >> shift) << shift;
-        return new Node(parent, level-1, nodeSize);
+        return new Node(parent, level - 1, nodeSize);
       }
     }
   }
 
   private boolean validRowId(String[] rowArgs) {
-    return ((rowArgs.length == 4) && (rowArgs[0] != null) && (rowArgs[1] != null) && (rowArgs[2] != null) && (rowArgs[3] != null));
+    return ((rowArgs.length == 4) && (rowArgs[0] != null) && (rowArgs[1] != null)
+        && (rowArgs[2] != null) && (rowArgs[3] != null));
   }
 
   public static String generateRootId(int nodeSize) {

--- a/stresso/src/main/java/stresso/trie/NodeObserver.java
+++ b/stresso/src/main/java/stresso/trie/NodeObserver.java
@@ -1,16 +1,20 @@
 /*
- * Copyright 2014 Stresso authors (see AUTHORS)
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied. See the License for the specific language governing permissions and limitations under
- * the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
+
 package stresso.trie;
 
 import java.util.Map;

--- a/stresso/src/main/java/stresso/trie/NumberLoader.java
+++ b/stresso/src/main/java/stresso/trie/NumberLoader.java
@@ -1,16 +1,20 @@
 /*
- * Copyright 2014 Stresso authors (see AUTHORS)
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied. See the License for the specific language governing permissions and limitations under
- * the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
+
 package stresso.trie;
 
 import java.util.Map;

--- a/stresso/src/main/java/stresso/trie/Print.java
+++ b/stresso/src/main/java/stresso/trie/Print.java
@@ -1,15 +1,18 @@
 /*
- * Copyright 2014 Stresso authors (see AUTHORS)
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied. See the License for the specific language governing permissions and limitations under
- * the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package stresso.trie;
@@ -69,7 +72,7 @@ public class Print {
     try (FluoClient client = FluoFactory.newClient(config); Snapshot snap = client.newSnapshot()) {
 
       StressoConfig sconf = StressoConfig.retrieve(client);
-      
+
       RowScanner rows = snap.scanner().over(Span.prefix(String.format("%02d:", sconf.stopLevel)))
           .fetch(Constants.COUNT_SEEN_COL, Constants.COUNT_WAIT_COL).byRow().build();
 
@@ -112,7 +115,7 @@ public class Print {
     }
 
     FluoConfiguration fconf = new FluoConfiguration(new File(args[0])).setApplicationName(args[1]);
-    
+
     Stats stats = getStats(fconf);
 
     System.out.println("Total at root : " + (stats.totalSeen + stats.totalWait));

--- a/stresso/src/main/java/stresso/trie/Split.java
+++ b/stresso/src/main/java/stresso/trie/Split.java
@@ -1,15 +1,18 @@
 /*
- * Copyright 2014 Stresso authors (see AUTHORS)
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied. See the License for the specific language governing permissions and limitations under
- * the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package stresso.trie;
@@ -58,8 +61,9 @@ public class Split {
 
       while (level >= sconf.stopLevel) {
         int numTablets = maxTablets;
-        if (numTablets == 0)
+        if (numTablets == 0) {
           break;
+        }
 
         TreeSet<Text> splits = genSplits(level, numTablets);
         tableOps.addSplits(table, splits);

--- a/stresso/src/main/java/stresso/trie/StressoConfig.java
+++ b/stresso/src/main/java/stresso/trie/StressoConfig.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package stresso.trie;
 
 import org.apache.fluo.api.client.FluoClient;
@@ -8,12 +25,12 @@ import org.apache.fluo.api.config.SimpleConfiguration;
 public class StressoConfig {
   public final int nodeSize;
   public final int stopLevel;
-  
+
   public StressoConfig(int nodeSize, int stopLevel) {
     this.nodeSize = nodeSize;
     this.stopLevel = stopLevel;
   }
-  
+
   public static StressoConfig retrieve(FluoConfiguration fc) {
     try (FluoClient client = FluoFactory.newClient(fc)) {
       return retrieve(client);
@@ -22,6 +39,7 @@ public class StressoConfig {
 
   public static StressoConfig retrieve(FluoClient client) {
     SimpleConfiguration ac = client.getAppConfiguration();
-    return new StressoConfig(ac.getInt(Constants.NODE_SIZE_PROP), ac.getInt(Constants.STOP_LEVEL_PROP));
+    return new StressoConfig(ac.getInt(Constants.NODE_SIZE_PROP),
+        ac.getInt(Constants.STOP_LEVEL_PROP));
   }
 }

--- a/stresso/src/main/java/stresso/trie/StressoObserverProvider.java
+++ b/stresso/src/main/java/stresso/trie/StressoObserverProvider.java
@@ -1,9 +1,26 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package stresso.trie;
+
+import org.apache.fluo.api.observer.ObserverProvider;
 
 import static org.apache.fluo.api.observer.Observer.NotificationType.STRONG;
 import static stresso.trie.Constants.COUNT_WAIT_COL;
-
-import org.apache.fluo.api.observer.ObserverProvider;
 
 public class StressoObserverProvider implements ObserverProvider {
   @Override

--- a/stresso/src/main/java/stresso/trie/Unique.java
+++ b/stresso/src/main/java/stresso/trie/Unique.java
@@ -1,11 +1,12 @@
 /*
- * Copyright 2014 Stresso authors (see AUTHORS)
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -46,9 +47,11 @@ public class Unique extends Configured implements Tool {
     UNIQUE;
   }
 
-  public static class UniqueReducer extends MapReduceBase implements Reducer<LongWritable,NullWritable,LongWritable,NullWritable> {
+  public static class UniqueReducer extends MapReduceBase
+      implements Reducer<LongWritable, NullWritable, LongWritable, NullWritable> {
     @Override
-    public void reduce(LongWritable key, Iterator<NullWritable> values, OutputCollector<LongWritable,NullWritable> output, Reporter reporter) throws IOException {
+    public void reduce(LongWritable key, Iterator<NullWritable> values,
+        OutputCollector<LongWritable, NullWritable> output, Reporter reporter) throws IOException {
       reporter.getCounter(Stats.UNIQUE).increment(1);
     }
   }
@@ -87,12 +90,12 @@ public class Unique extends Configured implements Tool {
     job.setOutputFormat(NullOutputFormat.class);
 
     job.set("mapreduce.job.classloader", "true");
-    
+
     RunningJob runningJob = JobClient.runJob(job);
     runningJob.waitForCompletion();
     numUnique = (int) runningJob.getCounters().getCounter(Stats.UNIQUE);
 
-    log.debug("numUnique : "+numUnique);
+    log.debug("numUnique : " + numUnique);
 
     return runningJob.isSuccessful() ? 0 : -1;
 

--- a/stresso/src/test/java/stresso/ITBase.java
+++ b/stresso/src/test/java/stresso/ITBase.java
@@ -1,17 +1,19 @@
 /*
- * Copyright 2017 Stresso authors (see AUTHORS)
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied. See the License for the specific language governing permissions and limitations under
- * the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
-
 
 package stresso;
 
@@ -42,10 +44,10 @@ public class ITBase {
   protected final static String USER = "root";
   protected final static String PASSWORD = "ITSecret";
   protected final static String TABLE_BASE = "table";
-  protected final static String IT_INSTANCE_NAME_PROP = FluoConfiguration.FLUO_PREFIX
-      + ".it.instance.name";
-  protected final static String IT_INSTANCE_CLEAR_PROP = FluoConfiguration.FLUO_PREFIX
-      + ".it.instance.clear";
+  protected final static String IT_INSTANCE_NAME_PROP =
+      FluoConfiguration.FLUO_PREFIX + ".it.instance.name";
+  protected final static String IT_INSTANCE_CLEAR_PROP =
+      FluoConfiguration.FLUO_PREFIX + ".it.instance.clear";
 
   protected static String instanceName;
   protected static Connector conn;
@@ -54,7 +56,7 @@ public class ITBase {
   private static boolean startedCluster = false;
 
   private static AtomicInteger tableCounter = new AtomicInteger(1);
-  protected static AtomicInteger testCounter = new AtomicInteger();
+  protected static final AtomicInteger testCounter = new AtomicInteger();
 
   protected FluoConfiguration config;
   protected FluoClient client;
@@ -88,7 +90,7 @@ public class ITBase {
     }
   }
 
-  protected void preInit(FluoConfiguration config){}
+  protected void preInit(FluoConfiguration config) {}
 
   public String getCurTableName() {
     return TABLE_BASE + tableCounter.get();

--- a/stresso/src/test/java/stresso/TrieBasicIT.java
+++ b/stresso/src/test/java/stresso/TrieBasicIT.java
@@ -1,16 +1,20 @@
 /*
- * Copyright 2014 Stresso authors (see AUTHORS)
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied. See the License for the specific language governing permissions and limitations under
- * the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
+
 package stresso;
 
 import java.util.HashSet;
@@ -107,8 +111,7 @@ public class TrieBasicIT extends ITBase {
         if (result == null) {
           log.error("Could not find root node");
           FluoITHelper.printFluoTable(client);
-        }
-        if (!result.equals(uniqueNum)) {
+        } else if (!result.equals(uniqueNum)) {
           log.error(
               "Count (" + result + ") at root node does not match expected (" + uniqueNum + "):");
           FluoITHelper.printFluoTable(client);

--- a/stresso/src/test/java/stresso/TrieMapRedIT.java
+++ b/stresso/src/test/java/stresso/TrieMapRedIT.java
@@ -1,16 +1,20 @@
 /*
- * Copyright 2014 Stresso authors (see AUTHORS)
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied. See the License for the specific language governing permissions and limitations under
- * the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
+
 package stresso;
 
 import java.io.File;

--- a/stresso/src/test/java/stresso/TrieStopLevelIT.java
+++ b/stresso/src/test/java/stresso/TrieStopLevelIT.java
@@ -1,15 +1,18 @@
 /*
- * Copyright 2014 Stresso authors (see AUTHORS)
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied. See the License for the specific language governing permissions and limitations under
- * the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package stresso;

--- a/webindex/.gitignore
+++ b/webindex/.gitignore
@@ -1,9 +1,2 @@
-*.class
-.idea/
-*.iml
-.classpath
-.project
-.settings
-target/
 /logs/
 /data/

--- a/webindex/README.md
+++ b/webindex/README.md
@@ -1,3 +1,20 @@
+<!--
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
 ![Webindex][logo]
 ---
 [![Build Status][ti]][tl] [![Apache License][li]][ll]

--- a/webindex/modules/core/pom.xml
+++ b/webindex/modules/core/pom.xml
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  Copyright 2015 Webindex authors (see AUTHORS)
-
-  Licensed under the Apache License, Version 2.0 (the "License");
-  you may not use this file except in compliance with the License.
-  You may obtain a copy of the License at
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
 
       http://www.apache.org/licenses/LICENSE-2.0
 
@@ -17,7 +18,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>io.github.astralway</groupId>
+    <groupId>org.apache.fluo</groupId>
     <artifactId>webindex-parent</artifactId>
     <version>0.0.1-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>

--- a/webindex/modules/core/src/main/java/webindex/core/Constants.java
+++ b/webindex/modules/core/src/main/java/webindex/core/Constants.java
@@ -1,15 +1,18 @@
 /*
- * Copyright 2015 Webindex authors (see AUTHORS)
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
- * 
- * http://www.apache.org/licenses/LICENSE-2.0
- * 
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied. See the License for the specific language governing permissions and limitations under
- * the License.
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package webindex.core;

--- a/webindex/modules/core/src/main/java/webindex/core/IndexClient.java
+++ b/webindex/modules/core/src/main/java/webindex/core/IndexClient.java
@@ -1,15 +1,18 @@
 /*
- * Copyright 2015 Webindex authors (see AUTHORS)
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
- * 
- * http://www.apache.org/licenses/LICENSE-2.0
- * 
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied. See the License for the specific language governing permissions and limitations under
- * the License.
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package webindex.core;
@@ -164,17 +167,16 @@ public class IndexClient {
     String cf = Constants.RANK;
     try {
       Scanner scanner = conn.createScanner(accumuloIndexTable, Authorizations.EMPTY);
-      Pager pager =
-          Pager.build(scanner, Range.prefix(row + ":"), PAGE_SIZE, entry -> {
-            if (entry.isNext()) {
-              pages.setNext(entry.getKey().getRowData().toString().split(":", 3)[2]);
-            } else {
-              String url =
-                  URL.fromUri(entry.getKey().getRowData().toString().split(":", 4)[3]).toString();
-              Long count = Long.parseLong(entry.getValue().toString());
-              pages.addPage(url, count);
-            }
-          });
+      Pager pager = Pager.build(scanner, Range.prefix(row + ":"), PAGE_SIZE, entry -> {
+        if (entry.isNext()) {
+          pages.setNext(entry.getKey().getRowData().toString().split(":", 3)[2]);
+        } else {
+          String url =
+              URL.fromUri(entry.getKey().getRowData().toString().split(":", 4)[3]).toString();
+          Long count = Long.parseLong(entry.getValue().toString());
+          pages.addPage(url, count);
+        }
+      });
       if (next.isEmpty()) {
         pager.read(pageNum);
       } else {
@@ -247,7 +249,8 @@ public class IndexClient {
     return links;
   }
 
-  public static void genDomainMutations(DomainUpdate update, long seq, Consumer<Mutation> consumer) {
+  public static void genDomainMutations(DomainUpdate update, long seq,
+      Consumer<Mutation> consumer) {
     Map<RowColumn, Bytes> oldData = genDomainData(update.getDomain(), update.getOldPageCount());
     Map<RowColumn, Bytes> newData = genDomainData(update.getDomain(), update.getNewPageCount());
     AccumuloTranslator.generateMutations(seq, oldData, newData, consumer);

--- a/webindex/modules/core/src/main/java/webindex/core/WebIndexConfig.java
+++ b/webindex/modules/core/src/main/java/webindex/core/WebIndexConfig.java
@@ -1,15 +1,18 @@
 /*
- * Copyright 2015 Webindex authors (see AUTHORS)
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
- * 
- * http://www.apache.org/licenses/LICENSE-2.0
- * 
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied. See the License for the specific language governing permissions and limitations under
- * the License.
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package webindex.core;
@@ -47,8 +50,8 @@ public class WebIndexConfig {
     try {
       return Integer.parseInt(numInstances);
     } catch (NumberFormatException e) {
-      throw new IllegalStateException("Failed to parse value of " + numInstances + " for "
-          + WI_EXECUTOR_INSTANCES);
+      throw new IllegalStateException(
+          "Failed to parse value of " + numInstances + " for " + WI_EXECUTOR_INSTANCES);
     }
   }
 
@@ -90,8 +93,8 @@ public class WebIndexConfig {
   }
 
   protected static WebIndexConfig load(String configPath, boolean useEnv) {
-    Preconditions.checkArgument(new File(configPath).exists(), "Config does not exist at "
-        + configPath);
+    Preconditions.checkArgument(new File(configPath).exists(),
+        "Config does not exist at " + configPath);
     try {
       YamlReader reader = new YamlReader(new FileReader(configPath));
       WebIndexConfig config = reader.read(WebIndexConfig.class);

--- a/webindex/modules/core/src/main/java/webindex/core/models/DomainStats.java
+++ b/webindex/modules/core/src/main/java/webindex/core/models/DomainStats.java
@@ -1,15 +1,18 @@
 /*
- * Copyright 2015 Webindex authors (see AUTHORS)
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
- * 
- * http://www.apache.org/licenses/LICENSE-2.0
- * 
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied. See the License for the specific language governing permissions and limitations under
- * the License.
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package webindex.core.models;

--- a/webindex/modules/core/src/main/java/webindex/core/models/Link.java
+++ b/webindex/modules/core/src/main/java/webindex/core/models/Link.java
@@ -1,15 +1,18 @@
 /*
- * Copyright 2016 Webindex authors (see AUTHORS)
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
- * 
- * http://www.apache.org/licenses/LICENSE-2.0
- * 
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied. See the License for the specific language governing permissions and limitations under
- * the License.
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package webindex.core.models;

--- a/webindex/modules/core/src/main/java/webindex/core/models/Links.java
+++ b/webindex/modules/core/src/main/java/webindex/core/models/Links.java
@@ -1,15 +1,18 @@
 /*
- * Copyright 2015 Webindex authors (see AUTHORS)
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
- * 
- * http://www.apache.org/licenses/LICENSE-2.0
- * 
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied. See the License for the specific language governing permissions and limitations under
- * the License.
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package webindex.core.models;

--- a/webindex/modules/core/src/main/java/webindex/core/models/Page.java
+++ b/webindex/modules/core/src/main/java/webindex/core/models/Page.java
@@ -1,15 +1,18 @@
 /*
- * Copyright 2015 Webindex authors (see AUTHORS)
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
- * 
- * http://www.apache.org/licenses/LICENSE-2.0
- * 
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied. See the License for the specific language governing permissions and limitations under
- * the License.
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package webindex.core.models;

--- a/webindex/modules/core/src/main/java/webindex/core/models/Pages.java
+++ b/webindex/modules/core/src/main/java/webindex/core/models/Pages.java
@@ -1,15 +1,18 @@
 /*
- * Copyright 2015 Webindex authors (see AUTHORS)
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
- * 
- * http://www.apache.org/licenses/LICENSE-2.0
- * 
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied. See the License for the specific language governing permissions and limitations under
- * the License.
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package webindex.core.models;

--- a/webindex/modules/core/src/main/java/webindex/core/models/TopResults.java
+++ b/webindex/modules/core/src/main/java/webindex/core/models/TopResults.java
@@ -1,15 +1,18 @@
 /*
- * Copyright 2015 Webindex authors (see AUTHORS)
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
- * 
- * http://www.apache.org/licenses/LICENSE-2.0
- * 
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied. See the License for the specific language governing permissions and limitations under
- * the License.
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package webindex.core.models;

--- a/webindex/modules/core/src/main/java/webindex/core/models/URL.java
+++ b/webindex/modules/core/src/main/java/webindex/core/models/URL.java
@@ -1,15 +1,18 @@
 /*
- * Copyright 2016 Webindex authors (see AUTHORS)
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
- * 
- * http://www.apache.org/licenses/LICENSE-2.0
- * 
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied. See the License for the specific language governing permissions and limitations under
- * the License.
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package webindex.core.models;
@@ -256,8 +259,8 @@ public class URL implements Serializable {
       secure = true;
       port = 443;
     } else if (!idArgs[2].startsWith("o")) {
-      throw new IllegalArgumentException("Page ID does not have port info beg with 's' or 'o': "
-          + uri);
+      throw new IllegalArgumentException(
+          "Page ID does not have port info beg with 's' or 'o': " + uri);
     }
     if (idArgs[2].length() > 1) {
       port = Integer.parseInt(idArgs[2].substring(1));

--- a/webindex/modules/core/src/main/java/webindex/core/models/UriInfo.java
+++ b/webindex/modules/core/src/main/java/webindex/core/models/UriInfo.java
@@ -1,15 +1,18 @@
 /*
- * Copyright 2016 Webindex authors (see AUTHORS)
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
- * 
- * http://www.apache.org/licenses/LICENSE-2.0
- * 
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied. See the License for the specific language governing permissions and limitations under
- * the License.
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package webindex.core.models;

--- a/webindex/modules/core/src/main/java/webindex/core/models/export/DomainUpdate.java
+++ b/webindex/modules/core/src/main/java/webindex/core/models/export/DomainUpdate.java
@@ -1,15 +1,18 @@
 /*
- * Copyright 2016 Webindex authors (see AUTHORS)
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
- * 
- * http://www.apache.org/licenses/LICENSE-2.0
- * 
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied. See the License for the specific language governing permissions and limitations under
- * the License.
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package webindex.core.models.export;

--- a/webindex/modules/core/src/main/java/webindex/core/models/export/IndexUpdate.java
+++ b/webindex/modules/core/src/main/java/webindex/core/models/export/IndexUpdate.java
@@ -1,15 +1,18 @@
 /*
- * Copyright 2016 Webindex authors (see AUTHORS)
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
- * 
- * http://www.apache.org/licenses/LICENSE-2.0
- * 
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied. See the License for the specific language governing permissions and limitations under
- * the License.
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package webindex.core.models.export;

--- a/webindex/modules/core/src/main/java/webindex/core/models/export/PageUpdate.java
+++ b/webindex/modules/core/src/main/java/webindex/core/models/export/PageUpdate.java
@@ -1,15 +1,18 @@
 /*
- * Copyright 2016 Webindex authors (see AUTHORS)
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
- * 
- * http://www.apache.org/licenses/LICENSE-2.0
- * 
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied. See the License for the specific language governing permissions and limitations under
- * the License.
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package webindex.core.models.export;

--- a/webindex/modules/core/src/main/java/webindex/core/models/export/UriUpdate.java
+++ b/webindex/modules/core/src/main/java/webindex/core/models/export/UriUpdate.java
@@ -1,15 +1,18 @@
 /*
- * Copyright 2016 Webindex authors (see AUTHORS)
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
- * 
- * http://www.apache.org/licenses/LICENSE-2.0
- * 
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied. See the License for the specific language governing permissions and limitations under
- * the License.
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package webindex.core.models.export;

--- a/webindex/modules/core/src/main/java/webindex/core/util/Pager.java
+++ b/webindex/modules/core/src/main/java/webindex/core/util/Pager.java
@@ -1,15 +1,18 @@
 /*
- * Copyright 2015 Webindex authors (see AUTHORS)
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
- * 
- * http://www.apache.org/licenses/LICENSE-2.0
- * 
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied. See the License for the specific language governing permissions and limitations under
- * the License.
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package webindex.core.util;

--- a/webindex/modules/core/src/test/java/webindex/core/WebIndexConfigTest.java
+++ b/webindex/modules/core/src/test/java/webindex/core/WebIndexConfigTest.java
@@ -1,15 +1,18 @@
 /*
- * Copyright 2015 Webindex authors (see AUTHORS)
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
- * 
- * http://www.apache.org/licenses/LICENSE-2.0
- * 
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied. See the License for the specific language governing permissions and limitations under
- * the License.
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package webindex.core;

--- a/webindex/modules/core/src/test/java/webindex/core/models/LinkTest.java
+++ b/webindex/modules/core/src/test/java/webindex/core/models/LinkTest.java
@@ -1,15 +1,18 @@
 /*
- * Copyright 2016 Webindex authors (see AUTHORS)
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
- * 
- * http://www.apache.org/licenses/LICENSE-2.0
- * 
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied. See the License for the specific language governing permissions and limitations under
- * the License.
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package webindex.core.models;

--- a/webindex/modules/core/src/test/java/webindex/core/models/PageTest.java
+++ b/webindex/modules/core/src/test/java/webindex/core/models/PageTest.java
@@ -1,15 +1,18 @@
 /*
- * Copyright 2015 Webindex authors (see AUTHORS)
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
- * 
- * http://www.apache.org/licenses/LICENSE-2.0
- * 
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied. See the License for the specific language governing permissions and limitations under
- * the License.
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package webindex.core.models;

--- a/webindex/modules/core/src/test/java/webindex/core/models/URLTest.java
+++ b/webindex/modules/core/src/test/java/webindex/core/models/URLTest.java
@@ -1,15 +1,18 @@
 /*
- * Copyright 2016 Webindex authors (see AUTHORS)
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
- * 
- * http://www.apache.org/licenses/LICENSE-2.0
- * 
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied. See the License for the specific language governing permissions and limitations under
- * the License.
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package webindex.core.models;
@@ -49,19 +52,17 @@ public class URLTest {
   @Test
   public void testBasic() throws ParseException {
 
-    String[] validUrls =
-        {"http://ab.com/", "https://ab.com/1/2/3", "https://ab.com:8080?1/2/3",
-            "http://ab.com#1/2/3", "https://ab.com/", "https://h.d.ab.com/1/2/3"};
+    String[] validUrls = {"http://ab.com/", "https://ab.com/1/2/3", "https://ab.com:8080?1/2/3",
+        "http://ab.com#1/2/3", "https://ab.com/", "https://h.d.ab.com/1/2/3"};
 
     for (String rawUrl : validUrls) {
       Assert.assertTrue(URL.isValid(rawUrl));
       Assert.assertEquals(rawUrl, from(rawUrl).toString());
     }
 
-    String[] failureUrls =
-        {"ab.com", "ab.com/1/2/3", "htttp://ab.com/", "httpss://ab.com/", "http:/ab.com/",
-            "http::/ab.com/", "http:///ab.com/", "hhttp://ab.com/", "http://a.com:/test/",
-            "http://a.com:"};
+    String[] failureUrls = {"ab.com", "ab.com/1/2/3", "htttp://ab.com/", "httpss://ab.com/",
+        "http:/ab.com/", "http::/ab.com/", "http:///ab.com/", "hhttp://ab.com/",
+        "http://a.com:/test/", "http://a.com:"};
 
     for (String rawUrl : failureUrls) {
       Assert.assertFalse(URL.isValid(rawUrl));
@@ -113,8 +114,8 @@ public class URLTest {
     Assert.assertEquals(url443("a.b.example.com", "/"), from("https://A.b.example.com/"));
     Assert.assertEquals(urlSecure("a.b.example.com", "/", 8329),
         from("https://a.b.Example.com:8329/"));
-    Assert
-        .assertEquals(urlOpen("a.b.example.com", "/", 8333), from("http://a.B.example.com:8333/"));
+    Assert.assertEquals(urlOpen("a.b.example.com", "/", 8333),
+        from("http://a.B.example.com:8333/"));
     Assert.assertEquals(url443("example.com", "/"), from("https://example.com/"));
     Assert.assertEquals(url80("example.com", "/b?1#2&3#4"), from("http://example.com/b?1#2&3#4"));
     Assert.assertEquals(urlOpen("example.com", "/b", 8080), from("http://example.com:8080/b"));

--- a/webindex/modules/data/pom.xml
+++ b/webindex/modules/data/pom.xml
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  Copyright 2015 Webindex authors (see AUTHORS)
-
-  Licensed under the Apache License, Version 2.0 (the "License");
-  you may not use this file except in compliance with the License.
-  You may obtain a copy of the License at
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
 
       http://www.apache.org/licenses/LICENSE-2.0
 
@@ -17,7 +18,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>io.github.astralway</groupId>
+    <groupId>org.apache.fluo</groupId>
     <artifactId>webindex-parent</artifactId>
     <version>0.0.1-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
@@ -41,10 +42,6 @@
     <dependency>
       <groupId>commons-lang</groupId>
       <artifactId>commons-lang</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>io.github.astralway</groupId>
-      <artifactId>webindex-core</artifactId>
     </dependency>
     <dependency>
       <groupId>org.apache.accumulo</groupId>
@@ -79,6 +76,10 @@
     <dependency>
       <groupId>org.apache.fluo</groupId>
       <artifactId>fluo-recipes-spark</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.fluo</groupId>
+      <artifactId>webindex-core</artifactId>
     </dependency>
     <dependency>
       <groupId>org.netpreserve.commons</groupId>

--- a/webindex/modules/data/src/main/java/webindex/data/CalcSplits.java
+++ b/webindex/modules/data/src/main/java/webindex/data/CalcSplits.java
@@ -1,15 +1,18 @@
 /*
- * Copyright 2015 Webindex authors (see AUTHORS)
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
- * 
- * http://www.apache.org/licenses/LICENSE-2.0
- * 
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied. See the License for the specific language governing permissions and limitations under
- * the License.
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package webindex.data;
@@ -51,9 +54,8 @@ public class CalcSplits {
 
       IndexStats stats = new IndexStats(ctx);
 
-      final JavaPairRDD<Text, ArchiveReader> archives =
-          ctx.newAPIHadoopFile(dataDir, WARCFileInputFormat.class, Text.class, ArchiveReader.class,
-              new Configuration());
+      final JavaPairRDD<Text, ArchiveReader> archives = ctx.newAPIHadoopFile(dataDir,
+          WARCFileInputFormat.class, Text.class, ArchiveReader.class, new Configuration());
 
       JavaRDD<Page> pages = IndexUtil.createPages(archives);
 

--- a/webindex/modules/data/src/main/java/webindex/data/Configure.java
+++ b/webindex/modules/data/src/main/java/webindex/data/Configure.java
@@ -1,15 +1,18 @@
 /*
- * Copyright 2015 Webindex authors (see AUTHORS)
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
- * 
- * http://www.apache.org/licenses/LICENSE-2.0
- * 
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied. See the License for the specific language governing permissions and limitations under
- * the License.
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package webindex.data;
@@ -39,8 +42,8 @@ public class Configure {
     }
     WebIndexConfig webIndexConfig = WebIndexConfig.load(args[0]);
     String appPropsPath = args[1];
-    Preconditions.checkArgument(new File(appPropsPath).exists(), "File does not exist: "
-        + appPropsPath);
+    Preconditions.checkArgument(new File(appPropsPath).exists(),
+        "File does not exist: " + appPropsPath);
 
     FluoConfiguration fluoConfig =
         new FluoConfiguration(new File(webIndexConfig.getConnPropsPath()));
@@ -53,7 +56,8 @@ public class Configure {
     FluoConfiguration appConfig = new FluoConfiguration();
     env.configureApplication(fluoConfig, appConfig);
     Iterator<String> iter = appConfig.getKeys();
-    try (PrintWriter out = new PrintWriter(new BufferedWriter(new FileWriter(appPropsPath, true)))) {
+    try (
+        PrintWriter out = new PrintWriter(new BufferedWriter(new FileWriter(appPropsPath, true)))) {
       while (iter.hasNext()) {
         String key = iter.next();
         out.println(key + " = " + appConfig.getRawString(key));

--- a/webindex/modules/data/src/main/java/webindex/data/Copy.java
+++ b/webindex/modules/data/src/main/java/webindex/data/Copy.java
@@ -1,15 +1,18 @@
 /*
- * Copyright 2015 Webindex authors (see AUTHORS)
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
- * 
- * http://www.apache.org/licenses/LICENSE-2.0
- * 
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied. See the License for the specific language governing permissions and limitations under
- * the License.
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package webindex.data;
@@ -75,30 +78,29 @@ public class Copy {
       final String prefix = WebIndexConfig.CC_URL_PREFIX;
       final String destDir = destPath.toString();
 
-      copyRDD
-          .foreachPartition(iter -> {
-            FileSystem fs = IndexEnv.getHDFS(hadoopConfDir);
-            iter.forEachRemaining(ccPath -> {
-              try {
-                Path dfsPath = new Path(destDir + "/" + getFilename(ccPath));
-                if (fs.exists(dfsPath)) {
-                  log.error("File {} exists in HDFS and should have been previously filtered",
-                      dfsPath.getName());
-                } else {
-                  String urlToCopy = prefix + ccPath;
-                  log.info("Starting copy of {} to {}", urlToCopy, destDir);
-                  try (OutputStream out = fs.create(dfsPath);
-                      BufferedInputStream in =
-                          new BufferedInputStream(new URL(urlToCopy).openStream())) {
-                    IOUtils.copy(in, out);
-                  }
-                  log.info("Created {}", dfsPath.getName());
-                }
-              } catch (IOException e) {
-                log.error("Exception while copying {}", ccPath, e);
+      copyRDD.foreachPartition(iter -> {
+        FileSystem fs = IndexEnv.getHDFS(hadoopConfDir);
+        iter.forEachRemaining(ccPath -> {
+          try {
+            Path dfsPath = new Path(destDir + "/" + getFilename(ccPath));
+            if (fs.exists(dfsPath)) {
+              log.error("File {} exists in HDFS and should have been previously filtered",
+                  dfsPath.getName());
+            } else {
+              String urlToCopy = prefix + ccPath;
+              log.info("Starting copy of {} to {}", urlToCopy, destDir);
+              try (OutputStream out = fs.create(dfsPath);
+                  BufferedInputStream in =
+                      new BufferedInputStream(new URL(urlToCopy).openStream())) {
+                IOUtils.copy(in, out);
               }
-            });
-          });
+              log.info("Created {}", dfsPath.getName());
+            }
+          } catch (IOException e) {
+            log.error("Exception while copying {}", ccPath, e);
+          }
+        });
+      });
     }
   }
 }

--- a/webindex/modules/data/src/main/java/webindex/data/FluoApp.java
+++ b/webindex/modules/data/src/main/java/webindex/data/FluoApp.java
@@ -1,15 +1,18 @@
 /*
- * Copyright 2015 Webindex authors (see AUTHORS)
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
- * 
- * http://www.apache.org/licenses/LICENSE-2.0
- * 
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied. See the License for the specific language governing permissions and limitations under
- * the License.
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package webindex.data;

--- a/webindex/modules/data/src/main/java/webindex/data/Init.java
+++ b/webindex/modules/data/src/main/java/webindex/data/Init.java
@@ -1,15 +1,18 @@
 /*
- * Copyright 2015 Webindex authors (see AUTHORS)
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
- * 
- * http://www.apache.org/licenses/LICENSE-2.0
- * 
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied. See the License for the specific language governing permissions and limitations under
- * the License.
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package webindex.data;
@@ -54,9 +57,8 @@ public class Init {
       try (JavaSparkContext ctx = new JavaSparkContext(sparkConf)) {
         IndexStats stats = new IndexStats(ctx);
 
-        final JavaPairRDD<Text, ArchiveReader> archives =
-            ctx.newAPIHadoopFile(dataDir, WARCFileInputFormat.class, Text.class,
-                ArchiveReader.class, new Configuration());
+        final JavaPairRDD<Text, ArchiveReader> archives = ctx.newAPIHadoopFile(dataDir,
+            WARCFileInputFormat.class, Text.class, ArchiveReader.class, new Configuration());
 
         JavaRDD<Page> pages = IndexUtil.createPages(archives);
 

--- a/webindex/modules/data/src/main/java/webindex/data/LoadHdfs.java
+++ b/webindex/modules/data/src/main/java/webindex/data/LoadHdfs.java
@@ -1,15 +1,18 @@
 /*
- * Copyright 2015 Webindex authors (see AUTHORS)
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
- * 
- * http://www.apache.org/licenses/LICENSE-2.0
- * 
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied. See the License for the specific language governing permissions and limitations under
- * the License.
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package webindex.data;
@@ -95,8 +98,8 @@ public class LoadHdfs {
                 for (ArchiveRecord record : reader) {
                   Page page = ArchiveUtil.buildPageIgnoreErrors(record);
                   if (page.getOutboundLinks().size() > 0) {
-                    log.info("Loading page {} with {} links", page.getUrl(), page
-                        .getOutboundLinks().size());
+                    log.info("Loading page {} with {} links", page.getUrl(),
+                        page.getOutboundLinks().size());
                     if (rateLimiter != null) {
                       rateLimiter.acquire();
                     }

--- a/webindex/modules/data/src/main/java/webindex/data/LoadS3.java
+++ b/webindex/modules/data/src/main/java/webindex/data/LoadS3.java
@@ -1,15 +1,18 @@
 /*
- * Copyright 2015 Webindex authors (see AUTHORS)
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
- * 
- * http://www.apache.org/licenses/LICENSE-2.0
- * 
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied. See the License for the specific language governing permissions and limitations under
- * the License.
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package webindex.data;
@@ -83,8 +86,8 @@ public class LoadS3 {
               for (ArchiveRecord record : reader) {
                 Page page = ArchiveUtil.buildPageIgnoreErrors(record);
                 if (page.getOutboundLinks().size() > 0) {
-                  log.info("Loading page {} with {} links", page.getUrl(), page.getOutboundLinks()
-                      .size());
+                  log.info("Loading page {} with {} links", page.getUrl(),
+                      page.getOutboundLinks().size());
                   if (rateLimiter != null) {
                     rateLimiter.acquire();
                   }

--- a/webindex/modules/data/src/main/java/webindex/data/TestParser.java
+++ b/webindex/modules/data/src/main/java/webindex/data/TestParser.java
@@ -1,15 +1,18 @@
 /*
- * Copyright 2015 Webindex authors (see AUTHORS)
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
- * 
- * http://www.apache.org/licenses/LICENSE-2.0
- * 
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied. See the License for the specific language governing permissions and limitations under
- * the License.
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package webindex.data;

--- a/webindex/modules/data/src/main/java/webindex/data/fluo/DomainCombineQ.java
+++ b/webindex/modules/data/src/main/java/webindex/data/fluo/DomainCombineQ.java
@@ -1,15 +1,18 @@
 /*
- * Copyright 2015 Webindex authors (see AUTHORS)
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
- * 
- * http://www.apache.org/licenses/LICENSE-2.0
- * 
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied. See the License for the specific language governing permissions and limitations under
- * the License.
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package webindex.data.fluo;

--- a/webindex/modules/data/src/main/java/webindex/data/fluo/IndexUpdateTranslator.java
+++ b/webindex/modules/data/src/main/java/webindex/data/fluo/IndexUpdateTranslator.java
@@ -1,15 +1,18 @@
 /*
- * Copyright 2015 Webindex authors (see AUTHORS)
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
- * 
- * http://www.apache.org/licenses/LICENSE-2.0
- * 
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied. See the License for the specific language governing permissions and limitations under
- * the License.
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package webindex.data.fluo;
@@ -56,9 +59,8 @@ public class IndexUpdateTranslator implements AccumuloTranslator<String, IndexUp
       linksExported.mark();
       IndexClient.genUriMutations((UriUpdate) export.getValue(), export.getSequence(), consumer);
     } else {
-      String msg =
-          "An object with an IndexUpdate class (" + export.getValue().getClass().toString()
-              + ") was placed on the export queue";
+      String msg = "An object with an IndexUpdate class (" + export.getValue().getClass().toString()
+          + ") was placed on the export queue";
       log.error(msg);
       throw new IllegalStateException(msg);
     }

--- a/webindex/modules/data/src/main/java/webindex/data/fluo/PageLoader.java
+++ b/webindex/modules/data/src/main/java/webindex/data/fluo/PageLoader.java
@@ -1,15 +1,18 @@
 /*
- * Copyright 2015 Webindex authors (see AUTHORS)
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
- * 
- * http://www.apache.org/licenses/LICENSE-2.0
- * 
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied. See the License for the specific language governing permissions and limitations under
- * the License.
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package webindex.data.fluo;

--- a/webindex/modules/data/src/main/java/webindex/data/fluo/PageObserver.java
+++ b/webindex/modules/data/src/main/java/webindex/data/fluo/PageObserver.java
@@ -1,15 +1,18 @@
 /*
- * Copyright 2015 Webindex authors (see AUTHORS)
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
- * 
- * http://www.apache.org/licenses/LICENSE-2.0
- * 
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied. See the License for the specific language governing permissions and limitations under
- * the License.
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package webindex.data.fluo;

--- a/webindex/modules/data/src/main/java/webindex/data/fluo/UriCombineQ.java
+++ b/webindex/modules/data/src/main/java/webindex/data/fluo/UriCombineQ.java
@@ -1,15 +1,18 @@
 /*
- * Copyright 2015 Webindex authors (see AUTHORS)
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
- * 
- * http://www.apache.org/licenses/LICENSE-2.0
- * 
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied. See the License for the specific language governing permissions and limitations under
- * the License.
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package webindex.data.fluo;

--- a/webindex/modules/data/src/main/java/webindex/data/fluo/WebindexObservers.java
+++ b/webindex/modules/data/src/main/java/webindex/data/fluo/WebindexObservers.java
@@ -1,28 +1,30 @@
 /*
- * Copyright 2015 Webindex authors (see AUTHORS)
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
- * 
- * http://www.apache.org/licenses/LICENSE-2.0
- * 
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied. See the License for the specific language governing permissions and limitations under
- * the License.
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package webindex.data.fluo;
 
 import org.apache.fluo.api.config.SimpleConfiguration;
 import org.apache.fluo.api.metrics.MetricsReporter;
-import org.apache.fluo.api.observer.ObserverProvider;
 import org.apache.fluo.api.observer.Observer.NotificationType;
+import org.apache.fluo.api.observer.ObserverProvider;
 import org.apache.fluo.recipes.accumulo.export.function.AccumuloExporter;
 import org.apache.fluo.recipes.core.combine.CombineQueue;
 import org.apache.fluo.recipes.core.combine.SummingCombiner;
 import org.apache.fluo.recipes.core.export.ExportQueue;
-
 import webindex.core.Constants;
 import webindex.core.models.UriInfo;
 import webindex.core.models.export.IndexUpdate;
@@ -59,8 +61,8 @@ public class WebindexObservers implements ObserverProvider {
         new IndexUpdateTranslator(reporter)));
 
     // Register an observer to process updates to the URI map.
-    uriQ.registerObserver(obsRegistry, UriInfo::reduce, new UriCombineQ.UriUpdateObserver(exportQ,
-        domainQ, reporter));
+    uriQ.registerObserver(obsRegistry, UriInfo::reduce,
+        new UriCombineQ.UriUpdateObserver(exportQ, domainQ, reporter));
 
     // Register an observer to process updates to the domain map.
     domainQ.registerObserver(obsRegistry, new SummingCombiner<>(),

--- a/webindex/modules/data/src/main/java/webindex/data/spark/IndexEnv.java
+++ b/webindex/modules/data/src/main/java/webindex/data/spark/IndexEnv.java
@@ -1,15 +1,18 @@
 /*
- * Copyright 2015 Webindex authors (see AUTHORS)
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
- * 
- * http://www.apache.org/licenses/LICENSE-2.0
- * 
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied. See the License for the specific language governing permissions and limitations under
- * the License.
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package webindex.data.spark;
@@ -207,9 +210,10 @@ public class IndexEnv {
     }
   }
 
-  public void configureApplication(FluoConfiguration connectionConfig, FluoConfiguration appConfig) {
-    FluoApp
-        .configureApplication(connectionConfig, appConfig, accumuloTable, numBuckets, numTablets);
+  public void configureApplication(FluoConfiguration connectionConfig,
+      FluoConfiguration appConfig) {
+    FluoApp.configureApplication(connectionConfig, appConfig, accumuloTable, numBuckets,
+        numTablets);
   }
 
   public void initializeIndexes(JavaSparkContext ctx, JavaRDD<Page> pages, IndexStats stats)
@@ -233,8 +237,8 @@ public class IndexEnv {
 
   public void saveRowColBytesToFluo(JavaSparkContext ctx, JavaPairRDD<RowColumn, Bytes> data)
       throws Exception {
-    new FluoSparkHelper(fluoConfig, ctx.hadoopConfiguration(), fluoTempDir).bulkImportRcvToFluo(
-        data, new BulkImportOptions().setAccumuloConnector(conn));
+    new FluoSparkHelper(fluoConfig, ctx.hadoopConfiguration(), fluoTempDir)
+        .bulkImportRcvToFluo(data, new BulkImportOptions().setAccumuloConnector(conn));
   }
 
   public void saveRowColBytesToAccumulo(JavaSparkContext ctx, JavaPairRDD<RowColumn, Bytes> data)

--- a/webindex/modules/data/src/main/java/webindex/data/spark/IndexStats.java
+++ b/webindex/modules/data/src/main/java/webindex/data/spark/IndexStats.java
@@ -1,15 +1,18 @@
 /*
- * Copyright 2015 Webindex authors (see AUTHORS)
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
- * 
- * http://www.apache.org/licenses/LICENSE-2.0
- * 
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied. See the License for the specific language governing permissions and limitations under
- * the License.
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package webindex.data.spark;

--- a/webindex/modules/data/src/main/java/webindex/data/util/ArchiveUtil.java
+++ b/webindex/modules/data/src/main/java/webindex/data/util/ArchiveUtil.java
@@ -1,15 +1,18 @@
 /*
- * Copyright 2015 Webindex authors (see AUTHORS)
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
- * 
- * http://www.apache.org/licenses/LICENSE-2.0
- * 
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied. See the License for the specific language governing permissions and limitations under
- * the License.
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package webindex.data.util;
@@ -61,9 +64,8 @@ public class ArchiveUtil {
       Page page = new Page(pageUrl.toUri());
       page.setCrawlDate(archiveRecord.getHeader().getDate());
       try {
-        JSONObject responseMeta =
-            json.getJSONObject("Envelope").getJSONObject("Payload-Metadata")
-                .getJSONObject("HTTP-Response-Metadata");
+        JSONObject responseMeta = json.getJSONObject("Envelope").getJSONObject("Payload-Metadata")
+            .getJSONObject("HTTP-Response-Metadata");
 
         if (archiveRecord.getHeader().getMimetype().equals("application/json")) {
           try {
@@ -96,8 +98,8 @@ public class ArchiveUtil {
           }
         }
         try {
-          page.setTitle(responseMeta.getJSONObject("HTML-Metadata").getJSONObject("Head")
-              .getString("Title"));
+          page.setTitle(
+              responseMeta.getJSONObject("HTML-Metadata").getJSONObject("Head").getString("Title"));
         } catch (JSONException e) {
           log.debug("Failed to retrieve title", e);
         }
@@ -118,8 +120,8 @@ public class ArchiveUtil {
     try {
       return buildPage(record);
     } catch (Exception e) {
-      log.info("Exception parsing ArchiveRecord with url {} due to {}",
-          record.getHeader().getUrl(), e.getMessage());
+      log.info("Exception parsing ArchiveRecord with url {} due to {}", record.getHeader().getUrl(),
+          e.getMessage());
       return Page.EMPTY;
     }
   }

--- a/webindex/modules/data/src/main/java/webindex/data/util/WARCFileInputFormat.java
+++ b/webindex/modules/data/src/main/java/webindex/data/util/WARCFileInputFormat.java
@@ -1,15 +1,18 @@
 /*
- * Copyright 2015 Webindex authors (see AUTHORS)
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
- * 
- * http://www.apache.org/licenses/LICENSE-2.0
- * 
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied. See the License for the specific language governing permissions and limitations under
- * the License.
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package webindex.data.util;

--- a/webindex/modules/data/src/main/java/webindex/data/util/WARCFileRecordReader.java
+++ b/webindex/modules/data/src/main/java/webindex/data/util/WARCFileRecordReader.java
@@ -1,15 +1,18 @@
 /*
- * Copyright 2015 Webindex authors (see AUTHORS)
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
- * 
- * http://www.apache.org/licenses/LICENSE-2.0
- * 
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied. See the License for the specific language governing permissions and limitations under
- * the License.
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package webindex.data.util;
@@ -43,8 +46,8 @@ public class WARCFileRecordReader extends RecordReader<Text, ArchiveReader> {
   private boolean hasBeenRead = false;
 
   @Override
-  public void initialize(InputSplit inputSplit, TaskAttemptContext context) throws IOException,
-      InterruptedException {
+  public void initialize(InputSplit inputSplit, TaskAttemptContext context)
+      throws IOException, InterruptedException {
     FileSplit split = (FileSplit) inputSplit;
     Configuration conf = context.getConfiguration();
     Path path = split.getPath();

--- a/webindex/modules/data/src/main/java/webindex/serialization/WebindexKryoFactory.java
+++ b/webindex/modules/data/src/main/java/webindex/serialization/WebindexKryoFactory.java
@@ -1,15 +1,18 @@
 /*
- * Copyright 2015 Webindex authors (see AUTHORS)
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
- * 
- * http://www.apache.org/licenses/LICENSE-2.0
- * 
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied. See the License for the specific language governing permissions and limitations under
- * the License.
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package webindex.serialization;

--- a/webindex/modules/data/src/test/java/webindex/data/SparkTestUtil.java
+++ b/webindex/modules/data/src/test/java/webindex/data/SparkTestUtil.java
@@ -1,15 +1,18 @@
 /*
- * Copyright 2015 Webindex authors (see AUTHORS)
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
- * 
- * http://www.apache.org/licenses/LICENSE-2.0
- * 
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied. See the License for the specific language governing permissions and limitations under
- * the License.
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package webindex.data;

--- a/webindex/modules/data/src/test/java/webindex/data/fluo/it/IndexIT.java
+++ b/webindex/modules/data/src/test/java/webindex/data/fluo/it/IndexIT.java
@@ -1,15 +1,18 @@
 /*
- * Copyright 2015 Webindex authors (see AUTHORS)
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
- * 
- * http://www.apache.org/licenses/LICENSE-2.0
- * 
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied. See the License for the specific language governing permissions and limitations under
- * the License.
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package webindex.data.fluo.it;
@@ -120,9 +123,8 @@ public class IndexIT extends AccumuloExportITBase {
 
     // Compare against actual
     try (FluoClient client = FluoFactory.newClient(getMiniFluo().getClientConfiguration())) {
-      boolean foundDiff =
-          !FluoITHelper.verifyAccumuloTable(getAccumuloConnector(), exportTable,
-              tuples2rcv(accumuloIndex.collect()));
+      boolean foundDiff = !FluoITHelper.verifyAccumuloTable(getAccumuloConnector(), exportTable,
+          tuples2rcv(accumuloIndex.collect()));
       foundDiff |= !FluoITHelper.verifyFluoTable(client, tuples2rcv(fluoIndex.collect()));
       if (foundDiff) {
         FluoITHelper.printFluoTable(client);
@@ -252,7 +254,7 @@ public class IndexIT extends AccumuloExportITBase {
   }
 
   private static List<RowColumnValue> tuples2rcv(List<Tuple2<RowColumn, Bytes>> linkIndex) {
-    return Lists.transform(linkIndex, t -> new RowColumnValue(t._1().getRow(), t._1().getColumn(),
-        t._2()));
+    return Lists.transform(linkIndex,
+        t -> new RowColumnValue(t._1().getRow(), t._1().getColumn(), t._2()));
   }
 }

--- a/webindex/modules/data/src/test/java/webindex/data/spark/Hex.java
+++ b/webindex/modules/data/src/test/java/webindex/data/spark/Hex.java
@@ -1,15 +1,18 @@
 /*
- * Copyright 2015 Webindex authors (see AUTHORS)
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
- * 
- * http://www.apache.org/licenses/LICENSE-2.0
- * 
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied. See the License for the specific language governing permissions and limitations under
- * the License.
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package webindex.data.spark;

--- a/webindex/modules/data/src/test/java/webindex/data/spark/IndexEnvTest.java
+++ b/webindex/modules/data/src/test/java/webindex/data/spark/IndexEnvTest.java
@@ -1,15 +1,18 @@
 /*
- * Copyright 2015 Webindex authors (see AUTHORS)
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
- * 
- * http://www.apache.org/licenses/LICENSE-2.0
- * 
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied. See the License for the specific language governing permissions and limitations under
- * the License.
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package webindex.data.spark;

--- a/webindex/modules/data/src/test/java/webindex/data/spark/IndexUtilTest.java
+++ b/webindex/modules/data/src/test/java/webindex/data/spark/IndexUtilTest.java
@@ -1,15 +1,18 @@
 /*
- * Copyright 2015 Webindex authors (see AUTHORS)
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
- * 
- * http://www.apache.org/licenses/LICENSE-2.0
- * 
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied. See the License for the specific language governing permissions and limitations under
- * the License.
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package webindex.data.spark;

--- a/webindex/modules/data/src/test/java/webindex/data/util/ArchiveUtilTest.java
+++ b/webindex/modules/data/src/test/java/webindex/data/util/ArchiveUtilTest.java
@@ -1,15 +1,18 @@
 /*
- * Copyright 2015 Webindex authors (see AUTHORS)
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
- * 
- * http://www.apache.org/licenses/LICENSE-2.0
- * 
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied. See the License for the specific language governing permissions and limitations under
- * the License.
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package webindex.data.util;
@@ -36,21 +39,18 @@ public class ArchiveUtilTest {
     Assert.assertNotNull(page);
     Assert.assertFalse(page.isEmpty());
 
-    Assert
-        .assertEquals(
-            "http://1079ishot.com/presale-password-trey-songz-young-jeezy-pre-christmas-bash/screen-shot-2011-10-27-at-11-12-06-am/",
-            page.getUrl());
-    Assert
-        .assertEquals(
-            "com.1079ishot>>o>/presale-password-trey-songz-young-jeezy-pre-christmas-bash/screen-shot-2011-10-27-at-11-12-06-am/",
-            page.getUri());
+    Assert.assertEquals(
+        "http://1079ishot.com/presale-password-trey-songz-young-jeezy-pre-christmas-bash/screen-shot-2011-10-27-at-11-12-06-am/",
+        page.getUrl());
+    Assert.assertEquals(
+        "com.1079ishot>>o>/presale-password-trey-songz-young-jeezy-pre-christmas-bash/screen-shot-2011-10-27-at-11-12-06-am/",
+        page.getUri());
 
     Assert.assertEquals("2015-04-18T03:35:13Z", page.getCrawlDate());
     Assert.assertEquals("nginx/1.6.2", page.getServer());
-    Assert
-        .assertEquals(
-            "Presale Password &#8211; Trey Songz &#038; Young Jeezy Pre-Christmas Bash Screen shot 2011-10-27 at ",
-            page.getTitle());
+    Assert.assertEquals(
+        "Presale Password &#8211; Trey Songz &#038; Young Jeezy Pre-Christmas Bash Screen shot 2011-10-27 at ",
+        page.getTitle());
     Assert.assertEquals(0, page.getOutboundLinks().size());
 
     ArchiveReader ar2 = WARCReaderFactory.get(new File("src/test/resources/wat-18.warc"));

--- a/webindex/modules/integration/pom.xml
+++ b/webindex/modules/integration/pom.xml
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  Copyright 2015 Webindex authors (see AUTHORS)
-
-  Licensed under the Apache License, Version 2.0 (the "License");
-  you may not use this file except in compliance with the License.
-  You may obtain a copy of the License at
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
 
       http://www.apache.org/licenses/LICENSE-2.0
 
@@ -17,7 +18,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>io.github.astralway</groupId>
+    <groupId>org.apache.fluo</groupId>
     <artifactId>webindex-parent</artifactId>
     <version>0.0.1-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
@@ -36,24 +37,6 @@
     <dependency>
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>io.github.astralway</groupId>
-      <artifactId>webindex-core</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>io.github.astralway</groupId>
-      <artifactId>webindex-data</artifactId>
-      <exclusions>
-        <exclusion>
-          <groupId>asm</groupId>
-          <artifactId>asm</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <dependency>
-      <groupId>io.github.astralway</groupId>
-      <artifactId>webindex-ui</artifactId>
     </dependency>
     <dependency>
       <groupId>org.apache.accumulo</groupId>
@@ -80,6 +63,24 @@
     <dependency>
       <groupId>org.apache.fluo</groupId>
       <artifactId>fluo-recipes-test</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.fluo</groupId>
+      <artifactId>webindex-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.fluo</groupId>
+      <artifactId>webindex-data</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>asm</groupId>
+          <artifactId>asm</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.fluo</groupId>
+      <artifactId>webindex-ui</artifactId>
     </dependency>
     <dependency>
       <groupId>org.netpreserve.commons</groupId>

--- a/webindex/modules/integration/src/main/java/webindex/integration/DevServer.java
+++ b/webindex/modules/integration/src/main/java/webindex/integration/DevServer.java
@@ -1,15 +1,18 @@
 /*
- * Copyright 2015 Webindex authors (see AUTHORS)
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
- * 
- * http://www.apache.org/licenses/LICENSE-2.0
- * 
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied. See the License for the specific language governing permissions and limitations under
- * the License.
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package webindex.integration;
@@ -124,15 +127,10 @@ public class DevServer {
 
       try (LoaderExecutor le = client.newLoaderExecutor()) {
 
-        Files
-            .lines(dataPath)
-            .map(json -> Page.fromJson(gson, json))
-            .forEach(
-                page -> {
-                  log.debug("Loading page {} with {} links", page.getUrl(), page.getOutboundLinks()
-                      .size());
-                  le.execute(PageLoader.updatePage(page));
-                });
+        Files.lines(dataPath).map(json -> Page.fromJson(gson, json)).forEach(page -> {
+          log.debug("Loading page {} with {} links", page.getUrl(), page.getOutboundLinks().size());
+          le.execute(PageLoader.updatePage(page));
+        });
       }
 
       log.info("Finished loading data. Waiting for observers to finish...");

--- a/webindex/modules/integration/src/main/java/webindex/integration/DevServerOpts.java
+++ b/webindex/modules/integration/src/main/java/webindex/integration/DevServerOpts.java
@@ -1,15 +1,18 @@
 /*
- * Copyright 2015 Webindex authors (see AUTHORS)
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
- * 
- * http://www.apache.org/licenses/LICENSE-2.0
- * 
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied. See the License for the specific language governing permissions and limitations under
- * the License.
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package webindex.integration;

--- a/webindex/modules/integration/src/main/java/webindex/integration/SampleData.java
+++ b/webindex/modules/integration/src/main/java/webindex/integration/SampleData.java
@@ -1,15 +1,18 @@
 /*
- * Copyright 2015 Webindex authors (see AUTHORS)
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
- * 
- * http://www.apache.org/licenses/LICENSE-2.0
- * 
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied. See the License for the specific language governing permissions and limitations under
- * the License.
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package webindex.integration;

--- a/webindex/modules/integration/src/test/java/webindex/integration/DevServerIT.java
+++ b/webindex/modules/integration/src/test/java/webindex/integration/DevServerIT.java
@@ -1,15 +1,18 @@
 /*
- * Copyright 2015 Webindex authors (see AUTHORS)
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
- * 
- * http://www.apache.org/licenses/LICENSE-2.0
- * 
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied. See the License for the specific language governing permissions and limitations under
- * the License.
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package webindex.integration;

--- a/webindex/modules/ui/pom.xml
+++ b/webindex/modules/ui/pom.xml
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  Copyright 2015 Webindex authors (see AUTHORS)
-
-  Licensed under the Apache License, Version 2.0 (the "License");
-  you may not use this file except in compliance with the License.
-  You may obtain a copy of the License at
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
 
       http://www.apache.org/licenses/LICENSE-2.0
 
@@ -17,7 +18,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>io.github.astralway</groupId>
+    <groupId>org.apache.fluo</groupId>
     <artifactId>webindex-parent</artifactId>
     <version>0.0.1-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
@@ -34,10 +35,6 @@
       <artifactId>spark-template-freemarker</artifactId>
     </dependency>
     <dependency>
-      <groupId>io.github.astralway</groupId>
-      <artifactId>webindex-core</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.apache.accumulo</groupId>
       <artifactId>accumulo-core</artifactId>
     </dependency>
@@ -48,6 +45,10 @@
     <dependency>
       <groupId>org.apache.fluo</groupId>
       <artifactId>fluo-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.fluo</groupId>
+      <artifactId>webindex-core</artifactId>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>

--- a/webindex/modules/ui/src/main/java/webindex/ui/WebServer.java
+++ b/webindex/modules/ui/src/main/java/webindex/ui/WebServer.java
@@ -1,15 +1,18 @@
 /*
- * Copyright 2015 Webindex authors (see AUTHORS)
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
- * 
- * http://www.apache.org/licenses/LICENSE-2.0
- * 
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied. See the License for the specific language governing permissions and limitations under
- * the License.
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package webindex.ui;
@@ -113,14 +116,16 @@ public class WebServer {
 
     get("/", (req, res) -> new ModelAndView(null, "home.ftl"), freeMarkerEngine);
 
-    get("/top", (req, res) -> new ModelAndView(Collections.singletonMap("top", getTop(req)),
-        "top.ftl"), freeMarkerEngine);
+    get("/top",
+        (req, res) -> new ModelAndView(Collections.singletonMap("top", getTop(req)), "top.ftl"),
+        freeMarkerEngine);
 
     Gson gson = new Gson();
     get("/api/top", (req, res) -> getTop(req), gson::toJson);
 
-    get("/page", (req, res) -> new ModelAndView(Collections.singletonMap("page", getPage(req)),
-        "page.ftl"), freeMarkerEngine);
+    get("/page",
+        (req, res) -> new ModelAndView(Collections.singletonMap("page", getPage(req)), "page.ftl"),
+        freeMarkerEngine);
     get("/api/page", (req, res) -> getPage(req), gson::toJson);
 
     get("/pages", (req, res) -> new ModelAndView(Collections.singletonMap("pages", getPages(req)),

--- a/webindex/pom.xml
+++ b/webindex/pom.xml
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  Copyright 2015 Webindex authors (see AUTHORS)
-
-  Licensed under the Apache License, Version 2.0 (the "License");
-  you may not use this file except in compliance with the License.
-  You may obtain a copy of the License at
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
 
       http://www.apache.org/licenses/LICENSE-2.0
 
@@ -17,11 +18,10 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>io.fluo</groupId>
-    <artifactId>fluo-io-parent</artifactId>
-    <version>2</version>
+    <groupId>org.apache.fluo</groupId>
+    <artifactId>fluo-examples</artifactId>
+    <version>1-SNAPSHOT</version>
   </parent>
-  <groupId>io.github.astralway</groupId>
   <artifactId>webindex-parent</artifactId>
   <version>0.0.1-SNAPSHOT</version>
   <packaging>pom</packaging>
@@ -80,21 +80,6 @@
         <groupId>commons-lang</groupId>
         <artifactId>commons-lang</artifactId>
         <version>2.6</version>
-      </dependency>
-      <dependency>
-        <groupId>io.github.astralway</groupId>
-        <artifactId>webindex-core</artifactId>
-        <version>${project.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>io.github.astralway</groupId>
-        <artifactId>webindex-data</artifactId>
-        <version>${project.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>io.github.astralway</groupId>
-        <artifactId>webindex-ui</artifactId>
-        <version>${project.version}</version>
       </dependency>
       <dependency>
         <groupId>junit</groupId>
@@ -166,6 +151,21 @@
         <groupId>org.apache.fluo</groupId>
         <artifactId>fluo-recipes-test</artifactId>
         <version>${fluo-recipes.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.fluo</groupId>
+        <artifactId>webindex-core</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.fluo</groupId>
+        <artifactId>webindex-data</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.fluo</groupId>
+        <artifactId>webindex-ui</artifactId>
+        <version>${project.version}</version>
       </dependency>
       <dependency>
         <groupId>org.apache.hadoop</groupId>


### PR DESCRIPTION
* Update license headers
* Fix RAT checks
* Apply formatter from parent POM
* Build all examples as a multi-module project
* Fix checkstyle and modernizer warnings
* Fix a few findbugs warnings (but not all... run with -Dfindbugs.skip)
* Use org.apache.fluo groupIds instead of old groupIds
* Update gitignore files

Some tests are still failing, but seems like an unrelated issue.